### PR TITLE
Gary.mulder/ray cluster

### DIFF
--- a/python/examples/rayproj/Dockerfile
+++ b/python/examples/rayproj/Dockerfile
@@ -10,12 +10,13 @@ WORKDIR $HOME
 # Build env for Kevlar
 ENV EXTRA_PKGS="gcc-9 g++-9 curl"
 RUN sudo apt update && \
-    sudo apt install -y $EXTRA_PKGS
+    sudo apt install -y $EXTRA_PKGS && \
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10 && \
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 10 
 
 # Install Python 3.x and Ray
 # Note: latest grpcio breaks Ray
-RUN id && \
-    conda install -y python=3.9 && \
+RUN conda install -y python=3.9 && \
     conda install -y grpcio==1.42 && \
     conda clean -y --all && \
     pip install --no-cache-dir ray==1.11.0
@@ -23,31 +24,27 @@ RUN id && \
 # Get latest Kevlar src
 RUN mkdir "$HOME/.ssh" 
 COPY id_rsa "$HOME/.ssh/id_rsa"
-#ENV GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i $HOME/id_rsa.github -o IdentitiesOnly=yes"
 ENV GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
-RUN id && \
-    sudo chown -R ray "$HOME/.ssh" && \
+ENV CC="gcc"
+ENV CXX="g++"
+RUN sudo chown -R ray "$HOME/.ssh" && \
     chmod 700 "$HOME/.ssh/id_rsa" && \
-    git clone --branch $BRANCH $REPO 
+    git clone --branch $BRANCH $REPO && \
+    cd kevlar/ && \
+    ./generate_bazelrc
 
-# Bazel build for Kevlar
-ENV CC="/usr/bin/gcc-9"
-ENV CXX="/usr/bin/g++-9"
+# Bazel build and install for pykevlar
 ENV PATH="$PATH:$HOME/bin"
 RUN mkdir "$HOME/bin" && \
     curl -Lo "$HOME/bin/bazel" https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64 && \
     chmod +x "$HOME/bin/bazel" && \
     cd kevlar/python/ && \
-    git status && \
-    bazel fetch //kevlar:kevlar
-
-# Build and install pykevar
-RUN cd kevlar/python/ && \
-    export CPLUS_INCLUDE_PATH="`bazel info output_base`/external/eigen" && \
-    pip install --no-cache-dir -vv --user -e .
+    #pip install --no-cache-dir -r requirements.txt && \
+    bazel build --config=gcc //python:pykevlar_wheel && \
+    pip install --no-cache-dir -v --user `bazel info bazel-genfiles`/python/dist/pykevlar*.whl
 
 # Clean up cached data and kevlar build
-RUN sudo sudo apt-get autoremove -y gcc-9 g++-9 curl && \
+RUN sudo sudo apt-get autoremove -y $EXTRA_PKGS && \
     sudo rm -rf /var/lib/apt/lists/* && \
     sudo apt-get clean
 


### PR DESCRIPTION
* Dockerised Ray cluster examples and docs added to `./python/examples/rayproj`
* Logging moved/added to the top of `./python/examples/fit_driver_example.py` and `./python/examples/fit_process_example.py`. The logging is mostly intended for headless Jenkins runs.

I didn't update the new model example scripts until we decide how `pyplot` output could be integrated into Jenkins (e.g. dump to PNG as save as a build artifact).