### PR TITLE
Faster INLA implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 /.vs
 .vscode/
+.history/
 /kevlar/CMakeSettings.json
 CMakeCache.txt
 CMakeFiles/

--- a/research/Pipfile
+++ b/research/Pipfile
@@ -12,9 +12,11 @@ pandas = "*"
 scipy = "*"
 matplotlib = "*"
 sympy = "*"
+numpyro = "*"
 
 [dev-packages]
 build = "*"
+black = "*"
 
 [requires]
 python_version = "3.8"

--- a/research/Pipfile.lock
+++ b/research/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1eca4f9526e438c1a42d43e5f66a7378704ad08d62bbc3a008d7acc7c8bbb688"
+            "sha256": "02e08ca09f76220df88aa73d7c09182e4a1854c2319a5d36393b4f2ac9eb5f40"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,13 @@
         ]
     },
     "default": {
-        "appnope": {
+        "absl-py": {
             "hashes": [
-                "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
-                "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"
+                "sha256:84e6dcdc69c947d0c13e5457d056bd43cade4c2393dce00d684aedea77ddc2a3",
+                "sha256:ac511215c01ee9ae47b19716599e8ccfa746f2e18de72bdf641b79b22afa27ea"
             ],
-            "markers": "platform_system == 'Darwin'",
-            "version": "==0.1.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "argon2-cffi": {
             "hashes": [
@@ -83,11 +83,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:577b9e1c36d2ada780d807c5622e889d43172466658c2eb239e97296965cdddb",
-                "sha256:ac98f868e1cb8eb9932a61be75b4f7018a118a490e7fdb424a74a982430cfcbd"
+                "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30",
+                "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.11.0"
+            "version": "==4.11.1"
         },
         "bleach": {
             "hashes": [
@@ -222,13 +222,20 @@
             ],
             "version": "==2.15.3"
         },
+        "flatbuffers": {
+            "hashes": [
+                "sha256:12158ab0272375eab8db2d663ae97370c33f152b27801fa6024e1d6105fd4dd2",
+                "sha256:3751954f0604580d3219ae49a85fafec9d85eec599c0b96226e1bc0b48e57474"
+            ],
+            "version": "==2.0"
+        },
         "fonttools": {
             "hashes": [
-                "sha256:236b29aee6b113e8f7bee28779c1230a86ad2aac9a74a31b0aedf57e7dfb62a4",
-                "sha256:2df636a3f402ef14593c6811dac0609563b8c374bd7850e76919eb51ea205426"
+                "sha256:59a90de72149893167e3d552ae2402c6874e006b9adc3feaf5f6d706fe20d392",
+                "sha256:b038d1a0dee0079de7ade57071e2e2aced6e35bd697de244ac62938b2b1628c1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.31.2"
+            "version": "==4.32.0"
         },
         "importlib-resources": {
             "hashes": [
@@ -240,18 +247,18 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:0868f5561729ade444011f8ca7d3502dc9f27f7f44e20f1d5fee7e1f2b7183a1",
-                "sha256:d840e3bf1c4b23bf6939f78dcdae639c9f6962e41d17e1c084a18c3c7f972d3a"
+                "sha256:0e28273e290858393e86e152b104e5506a79c13d25b951ac6eca220051b4be60",
+                "sha256:2b0987af43c0d4b62cecb13c592755f599f96f29aafe36c01731aaa96df30d39"
             ],
             "index": "pypi",
-            "version": "==6.12.1"
+            "version": "==6.13.0"
         },
         "ipython": {
             "hashes": [
                 "sha256:1b672bfd7a48d87ab203d9af8727a3b0174a4566b4091e9447c22fb63ea32857",
                 "sha256:70e5eb132cac594a34b5f799bd252589009905f05104728aea6a403ec2519dc1"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version >= '3.3'",
             "version": "==8.2.0"
         },
         "ipython-genutils": {
@@ -267,6 +274,30 @@
                 "sha256:e58ff58bc94d481e91ecb6e13a5cb96a87b6b8ade135e055603d0ca24593df38"
             ],
             "version": "==7.7.0"
+        },
+        "jax": {
+            "hashes": [
+                "sha256:bde2adb9c8b3abc10cadeab4199a0a8fe04de4dd39fac160140f4375fe24ce30"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.3.5"
+        },
+        "jaxlib": {
+            "hashes": [
+                "sha256:0f52894ae10e5f2a64254a93edc8736e805086d049a920a2b47645b91646930a",
+                "sha256:156af754040034c7c9261416eaffabd7d84baa457ae2a102fa2e1ba52cedf878",
+                "sha256:5c549c2cc248a45409c5b9cb0e67e69bc86f5447f6e7154eeb8588ac60f98818",
+                "sha256:66b396b78ff1149e05f0b0e9fa2128f5aaa2e33b20bdcaaba3c86fcc29def92c",
+                "sha256:7226370fe68517de3bb8aa125996d4bdf30a850a130b1f743b93abee31f0fdbd",
+                "sha256:816e937d01449fb892db89797257a7e6c912080718b244359c5d238fe008d1c4",
+                "sha256:89d3166663990a2f52ce2a4f56995d9ae471b7dbcbff73bbcf4902b87979dd8b",
+                "sha256:b6831e55e86a8ee2844c155b0cb6e95c042b1a79a0fd1110e66a9d6c65d321cd",
+                "sha256:bd2c13bcd40f61ef78de9be6763028438ed1d4d576485cec041ae09e9324383a",
+                "sha256:c14309e823a8233bdf840cdd88643b15b7a849a96bb88dface08a9c33bc410c1",
+                "sha256:db24f91e721bdb76fbe4e8387c2b224a6d8d310ec13a7850ebad04385198600c"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.3.5"
         },
         "jedi": {
             "hashes": [
@@ -327,10 +358,11 @@
         },
         "jupyterlab-pygments": {
             "hashes": [
-                "sha256:abfb880fd1561987efaefcb2d2ac75145d2a5d0139b1876d5be806e32f630008",
-                "sha256:cfcda0873626150932f438eccf0f8bf22bfa92345b814890ab360d666b254146"
+                "sha256:05f8056a18fec9ebef01f705443d81edb16bb03d27371f23c0ae135a85a76029",
+                "sha256:121da770930e348895f89d6bdfce7e7e6a8bb574162923f9c9ef5a20c61619c6"
             ],
-            "version": "==0.1.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.2.1"
         },
         "jupyterlab-widgets": {
             "hashes": [
@@ -498,21 +530,29 @@
             ],
             "version": "==1.2.1"
         },
+        "multipledispatch": {
+            "hashes": [
+                "sha256:407e6d8c5fa27075968ba07c4db3ef5f02bea4e871e959570eeb69ee39a6565b",
+                "sha256:a55c512128fb3f7c2efd2533f2550accb93c35f1045242ef74645fc92a2c3cba",
+                "sha256:a7ab1451fd0bf9b92cab3edbd7b205622fb767aeefb4fb536c2e3de9e0a38bea"
+            ],
+            "version": "==0.6.0"
+        },
         "nbclient": {
             "hashes": [
-                "sha256:40c52c9b5e3c31faecaee69f202b3f53e38d7c1c563de0fadde9d7eda0fdafe8",
-                "sha256:47ac905af59379913c1f8f541098d2550153cf8dc58553cbe18c702b181518b0"
+                "sha256:2eed35fc954716cdf0a01ea8cbdd9f9316761479008570059e2f5de29e139423",
+                "sha256:3f89a403c6badf24d2855a455b69a80985b3b27e04111243fdb6a88a28d27031"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.5.13"
+            "version": "==0.6.0"
         },
         "nbconvert": {
             "hashes": [
-                "sha256:21163a8e2073c07109ca8f398836e45efdba2aacea68d6f75a8a545fef070d4e",
-                "sha256:e01d219f55cc79f9701c834d605e8aa3acf35725345d3942e3983937f368ce14"
+                "sha256:223e46e27abe8596b8aed54301fadbba433b7ffea8196a68fd7b1ff509eee99d",
+                "sha256:c56dd0b8978a1811a5654f74c727ff16ca87dd5a43abd435a1c49b840fcd8360"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.4.5"
+            "version": "==6.5.0"
         },
         "nbformat": {
             "hashes": [
@@ -563,6 +603,22 @@
             ],
             "index": "pypi",
             "version": "==1.22.3"
+        },
+        "numpyro": {
+            "hashes": [
+                "sha256:50147a6aa1a88e9377e68b9d1e65db0a75dc6146cc20c52d69bc84fdb863829e",
+                "sha256:9e57470054212c6d12fd29a8d66e7e4815a4b7fafe428f49232a5395110cd620"
+            ],
+            "index": "pypi",
+            "version": "==0.9.1"
+        },
+        "opt-einsum": {
+            "hashes": [
+                "sha256:2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147",
+                "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3.0"
         },
         "packaging": {
             "hashes": [
@@ -676,11 +732,11 @@
         },
         "prometheus-client": {
             "hashes": [
-                "sha256:8f7a922dd5455ad524b6ba212ce8eb2b4b05e073f4ec7218287f88b1cac34750",
-                "sha256:f4aba3fdd1735852049f537c1f0ab177159b7ab76f271ecc4d2f45aa2a1d01f2"
+                "sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01",
+                "sha256:5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.14.0"
+            "version": "==0.14.1"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -760,11 +816,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pyrsistent": {
             "hashes": [
@@ -913,14 +969,6 @@
             ],
             "version": "==1.8.0"
         },
-        "setuptools": {
-            "hashes": [
-                "sha256:7999cbd87f1b6e1f33bf47efa368b224bed5e27b5ef2c4d46580186cbcb1a86a",
-                "sha256:a65e3802053e99fc64c6b3b29c11132943d5b8c8facbcc461157511546510967"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==62.0.0"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -960,13 +1008,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.13.3"
         },
-        "testpath": {
+        "tinycss2": {
             "hashes": [
-                "sha256:2f1b97e6442c02681ebe01bd84f531028a7caea1af3825000f52345c30285e0f",
-                "sha256:8ada9f80a2ac6fb0391aa7cdb1a7d11cfa8429f693eda83f74dde570fe6fa639"
+                "sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf",
+                "sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.6.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.1"
         },
         "tornado": {
             "hashes": [
@@ -1015,6 +1063,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==6.1"
         },
+        "tqdm": {
+            "hashes": [
+                "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d",
+                "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.64.0"
+        },
         "traitlets": {
             "hashes": [
                 "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7",
@@ -1022,6 +1078,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.1.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.1.1"
         },
         "wcwidth": {
             "hashes": [
@@ -1054,6 +1118,35 @@
         }
     },
     "develop": {
+        "black": {
+            "hashes": [
+                "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b",
+                "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176",
+                "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09",
+                "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a",
+                "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015",
+                "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79",
+                "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb",
+                "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20",
+                "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464",
+                "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968",
+                "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82",
+                "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21",
+                "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0",
+                "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265",
+                "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b",
+                "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a",
+                "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72",
+                "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce",
+                "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0",
+                "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a",
+                "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163",
+                "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad",
+                "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
+            ],
+            "index": "pypi",
+            "version": "==22.3.0"
+        },
         "build": {
             "hashes": [
                 "sha256:1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f",
@@ -1061,6 +1154,21 @@
             ],
             "index": "pypi",
             "version": "==0.7.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e",
+                "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.2"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
         },
         "packaging": {
             "hashes": [
@@ -1070,6 +1178,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==21.3"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
         "pep517": {
             "hashes": [
                 "sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0",
@@ -1077,21 +1192,37 @@
             ],
             "version": "==0.12.0"
         },
+        "platformdirs": {
+            "hashes": [
+                "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d",
+                "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.1"
+        },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11' and python_version >= '3.6'",
             "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.1.1"
         }
     }
 }

--- a/research/berry/constants.py
+++ b/research/berry/constants.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+# I got this data by deconstructing the graphs in in Figure 1 of Berry et al 2013.
+N_I = np.array([[i] * 4 for i in [10, 15, 20, 25, 30, 35]])
+
+Y_I = np.array(
+    [
+        [1, 6, 3, 3],
+        [3, 8, 5, 4],
+        [6, 9, 7, 5],
+        [7, 10, 8, 7],
+        [8, 10, 9, 8],
+        [11, 11, 10, 9],
+    ]
+)
+DATA = np.stack((Y_I, N_I), axis=2)
+
+N_I2 = np.array(
+    [
+        [10, 10, 10, 10],
+        [15, 15, 15, 15],
+        [20, 20, 20, 20],
+        [20, 20, 25, 25],
+        [20, 20, 30, 30],
+        [20, 20, 35, 35],
+    ]
+)
+
+Y_I2 = np.array(
+    [
+        [0, 1, 3, 3],
+        [0, 1, 4, 5],
+        [0, 1, 6, 6],
+        [0, 1, 6, 7],
+        [0, 1, 7, 8],
+        [0, 1, 9, 10],
+    ],
+    dtype=np.float64,
+)
+
+DATA2 = np.stack((Y_I2, N_I2), axis=2)

--- a/research/berry/mcmc.py
+++ b/research/berry/mcmc.py
@@ -8,50 +8,43 @@ import numpyro.distributions as dist
 def mcmc_berry(model, data, suc_thresh):
     logit_p1 = model.logit_p1
 
-    def mcmc_berry_model(y, n):
-        mu = numpyro.sample("mu", dist.Normal(-1.34, 10))
-        sigma2 = numpyro.sample("sigma2", dist.InverseGamma(0.0005, 0.000005))
-        theta = numpyro.sample(
-            "theta",
-            dist.MultivariateNormal(
-                mu, jax.numpy.diag(jax.numpy.repeat(jax.numpy.sqrt(sigma2), 4))
-            ),
-        )
-        with numpyro.plate("i", 4):
-            numpyro.sample(
-                "y",
-                dist.BinomialLogits(theta + logit_p1, total_count=n),
-                obs=y,
-            )
+    def mcmc_berry_model(ys, ns):
+        with numpyro.plate("i", 6, dim=-2):
+            mu = numpyro.sample("mu", dist.Normal(-1.34, 10))
+            sigma2 = numpyro.sample("sigma2", dist.InverseGamma(0.0005, 0.000005))
+            with numpyro.plate("j", 4, dim=-1):
+                theta = numpyro.sample(
+                    "theta",
+                    dist.Normal(mu, jax.numpy.sqrt(sigma2)),
+                )
+                numpyro.sample(
+                    "y",
+                    dist.BinomialLogits(theta + logit_p1, total_count=ns),
+                    obs=ys,
+                )
 
-    mcmc_stats = dict(
-        cilow=np.empty((6, 4)),
-        cihi=np.empty((6, 4)),
-        theta_map=np.empty((6, 4)),
-        exceedance=np.empty((6, 4)),
-    )
+    mcmc_stats = {}
     mcmc_data = []
-    for i in range(data.shape[0]):
-        y = data[i, ..., 0]
-        n = data[i, ..., 1]
-        nuts_kernel = NUTS(mcmc_berry_model)
-        mcmc = MCMC(
-            nuts_kernel, num_warmup=5000, num_samples=20000, thinning=5
-        )
-        rng_key = jax.random.PRNGKey(0)
-        mcmc.run(
-            rng_key,
-            y,
-            n,
-        )
-        x = mcmc.get_samples(group_by_chain=True)
-        summary = numpyro.diagnostics.summary(x, prob=0.95)
-        mcmc_stats["cilow"][i] = summary["theta"]["2.5%"]
-        mcmc_stats["cihi"][i] = summary["theta"]["97.5%"]
-        mcmc_stats["theta_map"][i] = summary["theta"]["mean"]
-        n_samples = x["theta"].shape[0] * x["theta"].shape[1]
-        mcmc_stats["exceedance"][i] = (
-            np.sum(x["theta"] > suc_thresh[i], axis=(0, 1)) / n_samples
-        )
-        mcmc_data.append(mcmc)
+    nuts_kernel = NUTS(mcmc_berry_model)
+    mcmc = MCMC(nuts_kernel, num_warmup=5000, num_samples=200_000, thinning=5, progress_bar=False)
+    rng_key = jax.random.PRNGKey(0)
+    mcmc.run(rng_key, data[..., 0], data[..., 1])
+    x = mcmc.get_samples(group_by_chain=True)
+    summary = numpyro.diagnostics.summary(x, prob=0.95)
+    mcmc_stats["cilow"] = summary["theta"]["2.5%"]
+    mcmc_stats["cihi"] = summary["theta"]["97.5%"]
+    mcmc_stats["theta_map"] = summary["theta"]["mean"]
+    n_samples = x["theta"].shape[0] * x["theta"].shape[1]
+    mcmc_stats["exceedance"] = (
+        np.sum(x["theta"] > suc_thresh, axis=(0, 1)) / n_samples
+    )
+    mcmc_data.append(mcmc)
     return mcmc_data, mcmc_stats
+
+
+if __name__ == "__main__":
+    import berry
+    from constants import DATA, DATA2
+
+    b = berry.Berry(sigma2_n=90, sigma2_bounds=(1e-8, 1e3))
+    mcmc_berry(b, DATA2, b.suc_thresh)


### PR DESCRIPTION
I had fun with this. Both the JAX and the C++ implementations are quite fast now.

On my machine, Jax takes 7us per simulation. I don't have much experience profiling and optimizing Jax so it was fun to learn the bits and pieces. vmap and jit were critical. Also, lax.while_loop helped a lot in getting the optimization loop to behave well. These JAX results appear to be partially parallelized - I see utilization of 200-300%. I tried running it on Google Colab in order to try running a GPU. On a K80, I was only slightly faster at 6us so I'm guessing the current code has some sections that make the GPU very frustrated. I haven't done much to debug or identify which sections are causing those problem. 

The C++ implementation is a little slower at 9us per simulation but it is not parallel at all. With a simple openmp for loop, we drop to 1.2us per simulation over 10 cores. 

There's definitely room to improve on these numbers but I figure this is good enough for now!

Not the most beautiful code but it seems good enough for now. Next step is to essentially copy Alex's Binomial dirty bayes model for kevlar and start running Berry models through kevlar! 