### PR TITLE
Implement inference caching

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 BasedOnStyle: Google
 IndentWidth: 4
-SortIncludes: CaseInsensitive
+SortIncludes: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,7 +103,15 @@
         "stack": "cpp",
         "__functional_base": "cpp",
         "alignedvector3": "cpp",
-        "typeindex": "cpp"
+        "typeindex": "cpp",
+        "*.ipp": "cpp",
+        "*.inc": "cpp",
+        "core": "cpp",
+        "geometry": "cpp",
+        "qtalignedmalloc": "cpp",
+        "matrixfunctions": "cpp"
     },
-    "C_Cpp.errorSquiggles": "Enabled"
+    "C_Cpp.errorSquiggles": "Enabled",
+    "editor.formatOnSave": false,
+    "cmake.configureOnOpen": false
 }

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -110,6 +110,7 @@ http_archive(
 
 http_archive(
     name = "com_google_tcmalloc",
+    sha256 = "2e5e6755e02b0275b1333199c2a128a57c0d48ec8838fdca9baccf3b0e939ad6",
     strip_prefix = "tcmalloc-a3717bc4fcade63c642f9b991fbdd64299896762",
     urls = ["https://github.com/google/tcmalloc/archive/a3717bc4fcade63c642f9b991fbdd64299896762.zip"],
 )


### PR DESCRIPTION
We pre-populate a cache containing posterior inferences for the entire
Berry space. The cache is simply an Eigen tensor of vectors.

It takes ~15 seconds to populate the cache. Using the cache, we can run
1 simulation over a 64^4 grid in about 0.8 core seconds.

The cache is not mutated after creation, so it is trivally thread safe.