### PR TITLE
Improve Jax INLA numerical stability

### DIFF
--- a/research/berry/berrylib/fast_inla.py
+++ b/research/berry/berrylib/fast_inla.py
@@ -6,7 +6,11 @@ import jax.numpy as jnp
 import numpy as np
 import scipy.linalg
 import scipy.stats
+from jax.config import config
 from scipy.special import logit
+
+# This line is critical for enabling 64-bit floats.
+config.update("jax_enable_x64", True)
 
 
 def logdet(m):
@@ -65,11 +69,11 @@ class FastINLA:
             jax.vmap(
                 jax.vmap(
                     jax_opt,
-                    in_axes=(None, None, 0, None, None, None),
-                    out_axes=(0, 0, 0, 0),
+                    in_axes=(None, None, 0, 0, 0, 0, None, None, None),
+                    out_axes=(0, 0, 0),
                 ),
-                in_axes=(0, 0, None, None, None, None),
-                out_axes=(0, 0, 0, 0),
+                in_axes=(0, 0, None, None, None, None, None, None, None),
+                out_axes=(0, 0, 0),
             )
         )
 
@@ -246,10 +250,13 @@ class FastINLA:
         """
         y = jnp.asarray(y)
         n = jnp.asarray(n)
-        num_iters, theta_max, hess_diag, hess_shift = self.jax_opt_vec(
+        num_iters, theta_max, hess_inv = self.jax_opt_vec(
             y,
             n,
+            self.sigma2_pts_jax,
             self.neg_precQ_jax,
+            self.precQ_eig_vals_jax,
+            self.precQ_eig_vecs_jax,
             self.logit_p1,
             self.mu_0,
             self.tol,
@@ -262,8 +269,7 @@ class FastINLA:
             self.log_prior_jax,
             self.precQ_eig_vals_jax,
             self.precQ_eig_vecs_jax,
-            hess_diag,
-            hess_shift,
+            hess_inv,
             self.sigma2_wts_jax,
             self.logit_p1,
             self.mu_0,
@@ -305,9 +311,23 @@ class FastINLA:
         return sigma2_post, exceedances, theta_max, theta_sigma
 
 
-def jax_opt(y, n, neg_precQ, logit_p1, mu_0, tol, max_iter=100, fast_loop=True):
+def jax_opt(
+    y,
+    n,
+    sigma2,
+    neg_precQ,
+    prec_eig_vals,
+    prec_eig_vecs,
+    logit_p1,
+    mu_0,
+    tol,
+    max_iter=100,
+    fast_loop=True,
+):
+    cov = jnp.full_like(neg_precQ, 100) + jnp.diag(jnp.repeat(sigma2, len(y)))
+
     def step(args):
-        i, theta_max, hess_diag, hess_shift, go = args
+        i, theta_max, hess_inv, go = args
         theta_m0 = theta_max - mu_0
         exp_theta_adj = jnp.exp(theta_max + logit_p1)
         C = 1.0 / (exp_theta_adj + 1)
@@ -316,12 +336,10 @@ def jax_opt(y, n, neg_precQ, logit_p1, mu_0, tol, max_iter=100, fast_loop=True):
         grad = neg_precQ.dot(theta_m0) + y - nCeta
         diag = nCeta * C
 
-        shift = neg_precQ[..., 0, 1]
-        prec_d = jnp.diag(neg_precQ) - shift
-        diag = prec_d - diag
-        step = -jax_faster_inv_product(diag, shift, grad)
-        go = jnp.square(step).sum() > tol * tol
-        return i + 1, theta_max + step, diag, shift, go
+        hess_inv = jax_fast_inv(-cov, -diag)
+        step = -hess_inv.dot(grad)
+        go = jnp.sum(step**2) > tol**2
+        return i + 1, theta_max + step, hess_inv, go
 
     # NOTE: Warm starting was not helpful but I left this code here in case it's
     # useful.
@@ -334,7 +352,7 @@ def jax_opt(y, n, neg_precQ, logit_p1, mu_0, tol, max_iter=100, fast_loop=True):
     # )
     n_arms = y.shape[0]
     theta_max0 = jnp.zeros(n_arms)
-    init_args = (jnp.int16(0), theta_max0, jnp.zeros(n_arms), jnp.float32(0), True)
+    init_args = (jnp.int16(0), theta_max0, jnp.zeros_like(cov), True)
 
     if fast_loop:
         out = jax.lax.while_loop(
@@ -342,14 +360,21 @@ def jax_opt(y, n, neg_precQ, logit_p1, mu_0, tol, max_iter=100, fast_loop=True):
         )
     else:
         args = init_args
-        step = jax.jit(step)
+        # step = jax.jit(step)
         for i in range(max_iter):
             args = step(args)
             out = args
             if not args[-1]:
                 break
-    i, theta_max, hess_diag, hess_shift, go = out
-    return i, theta_max, hess_diag, hess_shift
+    i, theta_max, hess_inv, go = out
+    return i, theta_max, hess_inv
+
+
+def jax_fast_inv(S, d):
+    for k in range(d.shape[0]):
+        offset = d[k] / (1 + d[k] * S[k, k])
+        S = S - (offset * (S[k, None, :] * S[:, None, k]))
+    return S
 
 
 def jax_faster_inv(D, S):
@@ -359,7 +384,8 @@ def jax_faster_inv(D, S):
     https://en.wikipedia.org/wiki/Sherman–Morrison_formula
     """
     D_inverse = 1.0 / D
-    multiplier = -S / (1 + S * D_inverse.sum())
+    # NB: reusing D_inverse in this line is numerically unstable
+    multiplier = -S / (1 + (S / D).sum())
     M = multiplier * jnp.outer(D_inverse, D_inverse)
     M = M + jnp.diag(D_inverse)
     return M
@@ -372,7 +398,8 @@ def jax_faster_inv_diag(D, S):
     https://en.wikipedia.org/wiki/Sherman–Morrison_formula
     """
     D_inverse = 1.0 / D
-    multiplier = -S / (1 + S * D_inverse.sum())
+    # NB: reusing D_inverse in this line is numerically unstable
+    multiplier = -S / (1 + (S / D).sum())
     return multiplier * D_inverse * D_inverse + D_inverse
 
 
@@ -382,9 +409,9 @@ def jax_faster_inv_product(D, S, G):
     This function uses "Sherman-Morrison" formula:
     https://en.wikipedia.org/wiki/Sherman–Morrison_formula
     """
-    D_inverse = 1.0 / D
-    multiplier = -S / (1 + S * D_inverse.sum())
-    return multiplier * D_inverse * jnp.dot(D_inverse, G) + D_inverse * G
+    D_norm = jnp.abs(D).sum()
+    D_normed = D / D_norm
+    return (-S * (G / D_normed).sum() / (D_norm + (S / D_normed).sum()) + G) / D
 
 
 def jax_faster_log_det(D, S):
@@ -396,7 +423,7 @@ def jax_faster_log_det(D, S):
     https://en.wikipedia.org/wiki/Matrix_determinant_lemma
     """
     detD_inverse = jnp.log(D).sum()
-    newdeterminant = detD_inverse + jnp.log1p(S * (1 / D).sum())
+    newdeterminant = detD_inverse + jnp.log1p((S / D).sum())
     return newdeterminant
 
 
@@ -407,13 +434,13 @@ def log_normal_pdf(x, mean, prec_eig_vals, prec_eig_vecs, omit_constants=True):
     """
     logdet = -jnp.sum(jnp.log(prec_eig_vals))
     U = prec_eig_vecs * jnp.sqrt(prec_eig_vals)
-    rank = len(prec_eig_vals)
     dev = x - mean
     # "maha" for "Mahalanobis distance".
     maha = jnp.square(jnp.dot(dev, U)).sum()
     if omit_constants:
         return -0.5 * (maha + logdet)
     else:
+        rank = len(prec_eig_vals)
         log2pi = jnp.log(2 * jnp.pi)
         return -0.5 * (rank * log2pi + maha + logdet)
 
@@ -432,8 +459,7 @@ def jax_calc_posterior_and_exceedances(
     log_prior,
     precQ_eig_vals,
     precQ_eig_vecs,
-    hess_diag,
-    hess_shift,
+    hess_inv,
     sigma2_wts,
     logit_p1,
     mu_0,
@@ -454,13 +480,16 @@ def jax_calc_posterior_and_exceedances(
         )
         + log_prior
     )
-    hess_inv_diag = jax.vmap(jax.vmap(jax_faster_inv_diag))(-hess_diag, -hess_shift)
-    logdet_hess_inv = -jax.vmap(jax.vmap(jax_faster_log_det))(-hess_diag, -hess_shift)
+    logdet_hess_inv = jax.vmap(jax.vmap(logdet))(-hess_inv)
     log_sigma2_post = logjoint + 0.5 * logdet_hess_inv
+
+    # This helps prevent underflow
+    log_sigma2_post -= jnp.nanmin(log_sigma2_post, axis=1)[:, None]
     sigma2_post = jnp.exp(log_sigma2_post)
+    sigma2_post = jnp.nan_to_num(sigma2_post, posinf=0, neginf=0)
     sigma2_post /= jnp.sum(sigma2_post * sigma2_wts, axis=1)[:, None]
 
-    theta_sigma = jnp.sqrt(hess_inv_diag)
+    theta_sigma = jnp.sqrt(jnp.diagonal(-hess_inv, axis1=2, axis2=3))
     exc_sigma2 = 1.0 - jax.scipy.stats.norm.cdf(
         thresh_theta,
         theta_max,

--- a/research/berry/jax_inla.ipynb
+++ b/research/berry/jax_inla.ipynb
@@ -1,16 +1,19 @@
 {
-    "cells": [{
+    "cells": [
+        {
             "cell_type": "code",
             "execution_count": 1,
             "metadata": {},
-            "outputs": [{
-                "name": "stderr",
-                "output_type": "stream",
-                "text": [
-                    "/home/const/mambaforge/envs/imprint/lib/python3.10/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-                    "  from .autonotebook import tqdm as notebook_tqdm\n"
-                ]
-            }],
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/home/const/mambaforge/envs/imprint/lib/python3.10/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+                        "  from .autonotebook import tqdm as notebook_tqdm\n"
+                    ]
+                }
+            ],
             "source": [
                 "import sys\n",
                 "\n",
@@ -20,38 +23,42 @@
                 "import matplotlib.pyplot as plt\n",
                 "\n",
                 "\n",
-                "from berrylib.constants import Y_I, Y_I2, N_I, N_I2\n"
+                "from berrylib.constants import Y_I, Y_I2, N_I, N_I2\n",
+                "from jax.config import config\n",
+                "config.update(\"jax_enable_x64\", False)\n",
+                "\n"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 160,
+            "execution_count": 27,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "0\n",
-                        "10000\n",
-                        "20000\n",
-                        "30000\n",
-                        "40000\n",
-                        "50000\n",
-                        "60000\n",
-                        "70000\n",
-                        "80000\n",
-                        "90000\n"
+                        "D 1000.0\n",
+                        "[0.00028571 0.00128571 0.00228571 0.00328571]\n",
+                        "D 100.0\n",
+                        "[-0.01  0.    0.01  0.02]\n",
+                        "D 10.0\n",
+                        "[-0.14390244 -0.04390244  0.05609756  0.15609756]\n",
+                        "D 1.0\n",
+                        "[-1.49376559 -0.49376559  0.50623441  1.50623441]\n",
+                        "D 0.1\n",
+                        "[-14.99375156  -4.99375156   5.00624844  15.00624844]\n",
+                        "D 0.01\n",
+                        "[-149.99375016  -49.99375016   50.00624984  150.00624984]\n",
+                        "D 0.001\n",
+                        "[-1499.99375002  -499.99375002   500.00624998  1500.00624998]\n",
+                        "D 0.0001\n",
+                        "[-14999.99375  -4999.99375   5000.00625  15000.00625]\n",
+                        "D 1e-05\n",
+                        "[-149999.99375  -49999.99375   50000.00625  150000.00625]\n",
+                        "D 1e-06\n",
+                        "[-1499999.99375  -499999.99375   500000.00625  1500000.00625]\n"
                     ]
-                },
-                {
-                    "data": {
-                        "text/plain": [
-                            "0"
-                        ]
-                    },
-                    "execution_count": 160,
-                    "metadata": {},
-                    "output_type": "execute_result"
                 }
             ],
             "source": [
@@ -61,207 +68,115 @@
                 "from functools import partial\n",
                 "\n",
                 "importlib.reload(berrylib.fast_inla)\n",
-                "from berrylib.fast_inla import FastINLA, jax_opt\n",
+                "from berrylib.fast_inla import FastINLA, jax_opt, jax_faster_inv_product\n",
                 "\n",
-                "# assert jax.config.read(\"jax_enable_x64\")\n",
-                "\n",
-                "fi = FastINLA(n_arms=2)\n",
-                "# sigma2 = jnp.array(1e5)\n",
-                "# y = jnp.array([0, 0, 30, 30])[jnp.newaxis]\n",
-                "# n = jnp.array([30, 30, 30, 30])[jnp.newaxis]\n",
-                "# # fi.jax_inference(y, n)\n",
-                "\n",
-                "\n",
-                "def jax_faster_inv(D, S):\n",
-                "    \"\"\"Compute the inverse of a diagonal matrix D plus a shift S.\n",
+                "def jax_faster_inv_product(D, S, G):\n",
+                "    \"\"\"Compute (diag(D)+S)^-1 @ G.\n",
                 "\n",
                 "    This function uses \"Sherman-Morrison\" formula:\n",
                 "    https://en.wikipedia.org/wiki/Sherman–Morrison_formula\n",
                 "    \"\"\"\n",
                 "    D_inverse = 1.0 / D\n",
-                "    multiplier = -S / (1 + S * D_inverse.sum())\n",
-                "    M = multiplier * jnp.outer(D_inverse, D_inverse)\n",
-                "    M = M + jnp.diag(D_inverse)\n",
-                "    return M\n",
+                "    multiplier = -S / (1 + (S / D).sum())\n",
+                "    # return D_inverse *(multiplier * jnp.dot(D_inverse, G) +  G)\n",
+                "    D_norm = jnp.abs(D).sum()\n",
+                "    D_normed = D / D_norm\n",
+                "    return (-S * (G / D_normed).sum() / (D_norm + (S  / D_normed).sum()) + G) / D\n",
                 "\n",
+                "Ds = jnp.arange(3, -7, -1)\n",
+                "S = 100\n",
+                "G = jnp.arange(1, 5)\n",
+                "for D in Ds:\n",
+                "    D = 10.0**D\n",
+                "    print('D', D)\n",
+                "    D = jnp.repeat(D, 4)\n",
+                "    D_inverse = 1.0 / D\n",
+                "    multiplier = -S / (1 + (S / D).sum())\n",
+                "    d_multiplier = -S / (D + S*len(D))\n",
+                "    a, b = D_inverse *(multiplier * jnp.dot(D_inverse, G)), D_inverse * G\n",
+                "    # print(\"inv\", D_inverse)\n",
+                "    # print(multiplier * D_inverse)\n",
+                "    # print(d_multiplier)\n",
+                "    print(jax_faster_inv_product(D, S, G))\n",
+                "    # print(jax_faster_inv_product(D, S, G) * D)\n",
+                "# assert jax.config.read(\"jax_enable_x64\")\n",
                 "\n",
-                "# @jax.jit\n",
-                "def jax_opt(y, neg_precQ, fast_loop=True):\n",
-                "    # y = jnp.array([29.65146991, 27.51985572])\n",
-                "    n = jnp.array([35, 35])\n",
-                "    # neg_precQ = jnp.array([[-28764.0366170816, 28764.031617082037], [28764.031617082037, -28764.0366170816]])\n",
-                "    logit_p1 = -0.8472978603872036\n",
-                "    mu_0 = -1.34\n",
-                "    tol = 0.001\n",
-                "\n",
-                "    def step(args):\n",
-                "        i, theta_max, hess_inv, go = args\n",
-                "        theta_m0 = theta_max - mu_0\n",
-                "        exp_theta_adj = jnp.exp(theta_max + logit_p1)\n",
-                "        nCeta = jnp.log(n) - jnp.log1p(exp_theta_adj) + (theta_max + logit_p1)\n",
-                "        diag = jnp.exp(nCeta - jnp.log1p(exp_theta_adj))\n",
-                "        nCeta = jnp.exp(nCeta)\n",
-                "\n",
-                "        grad = neg_precQ @ theta_m0 + y - nCeta\n",
-                "\n",
-                "        shift = neg_precQ[..., 0, 1]\n",
-                "        prec_d = jnp.diag(neg_precQ) - shift\n",
-                "        diag = prec_d - diag\n",
-                "\n",
-                "        # Apply the regularization suggested in: https://arxiv.org/abs/2112.02089\n",
-                "        H = 10\n",
-                "        reg = jnp.sqrt(H * jnp.linalg.norm(grad))\n",
-                "        diag += reg\n",
-                "\n",
-                "        hess_inv = jax_faster_inv(diag, shift)\n",
-                "        step = -hess_inv.dot(grad)\n",
-                "\n",
-                "        probit_step = 1 / (1 + jnp.exp(-theta_max))\n",
-                "        probit_step = probit_step * (1 - probit_step) * step\n",
-                "        go = jnp.max(jnp.abs(probit_step)) > tol\n",
-                "        # go = jnp.sum(step**2) > tol**2\n",
-                "        return i + 1, theta_max + step, hess_inv, go\n",
-                "\n",
-                "    n_arms = y.shape[0]\n",
-                "    theta_max0 = jnp.zeros(n_arms)\n",
-                "    init_args = (0, theta_max0, jnp.zeros((n_arms, n_arms)),  True)\n",
-                "    max_iter = 1000\n",
-                "\n",
-                "    if fast_loop:\n",
-                "        out = jax.lax.while_loop( lambda args: ((args[0] < max_iter) & args[-1]), step, init_args)\n",
-                "    else:\n",
-                "        args = init_args\n",
-                "        step = jax.jit(step)\n",
-                "        converged = False\n",
-                "        for i in range(max_iter):\n",
-                "            args = step(args)\n",
-                "            out = args\n",
-                "            if not args[-1]:\n",
-                "                converged = True\n",
-                "                break\n",
-                "    i, theta_max, hess_inv, go = out\n",
-                "    return theta_max, hess_inv\n",
-                "\n",
-                "\n",
-                "# def run(y, i):\n",
-                "#     # cov = jnp.full((fi.n_arms, fi.n_arms), fi.mu_sig_sq)\n",
-                "#     # cov = cov + jnp.diag(jnp.full(fi.n_arms, sigma2))\n",
-                "#     # # shift, prec_d = berrylib.fast_inla.jax_faster_inv(jnp.repeat(sigma2, arms), 100)\n",
-                "#     # # neg_precQ = -(jnp.diag(prec_d) + shift)\n",
-                "#     # neg_precQ = jnp.linalg.inv(cov)\n",
-                "#     n = np.array([[35, 35]])\n",
-                "\n",
-                "#     with open(\"out.txt\", \"a\") as f:\n",
-                "#         def p(x):\n",
-                "#             f.write(str(x) + \"\\n\")\n",
-                "#         p(y)\n",
-                "#         f.flush()\n",
-                "#     opt = jax_opt\n",
-                "#     theta_max, hess_inv = opt(\n",
-                "#     y[0],\n",
-                "#     n[0],\n",
-                "#     # fi.cov,\n",
-                "#     fi.neg_precQ[i],\n",
-                "#     # None,\n",
+                "# fi = FastINLA(n_arms=4)\n",
+                "# # sigma2 = jnp.array(1e5)\n",
+                "# y = jnp.array([0, 0, 30, 30])\n",
+                "# n = jnp.array([30, 30, 30, 30])\n",
+                "# # # fi.jax_inference(y, n)\n",
+                "# j = -2\n",
+                "# jax_opt(\n",
+                "#     y,\n",
+                "#     n,\n",
+                "#     fi.sigma2_pts_jax[j],\n",
+                "#     fi.neg_precQ_jax[j],\n",
+                "#     fi.precQ_eig_vals_jax[j],\n",
+                "#     fi.precQ_eig_vecs_jax[j],\n",
                 "#     fi.logit_p1,\n",
                 "#     fi.mu_0,\n",
                 "#     fi.tol,\n",
-                "#     )\n",
-                "#     if np.isnan(theta_max).any():\n",
-                "#         assert False, (y)\n",
-                "#     return theta_max\n",
-                "\n",
-                "trials = 100_000\n",
-                "\n",
-                "acc = 0\n",
-                "def test(y, j, fn=jax_opt):\n",
-                "    global acc\n",
-                "    if not fn(y, fi.neg_precQ[j]):\n",
-                "        acc +=1 #(i, y, j)\n",
-                "\n",
-                "# y = jnp.array([ 7.28087852, 19.92078862])\n",
-                "# j = 0\n",
-                "# test(y, j, fn=partial(jax_opt, fast_loop=False))\n",
-                "\n",
-                "fn = jax.jit(jax_opt)\n",
-                "acc = 0\n",
-                "for i in range(trials):\n",
-                "    arms = 2\n",
-                "    y = np.random.uniform(0, 35, size=(arms))\n",
-                "    if i % (trials // 10) == 0:\n",
-                "        print(i)\n",
-                "    for j in range(15):\n",
-                "        test(y, j, fn=fn)\n",
-                "# # %timeit run()\n",
-                "# _, exc, _, _ = fi.jax_inference(Y_I2, N_I2)\n",
-                "# exc[-1]\n",
-                "# ret = fi.jax_inference(Y_I2, N_I2)\n",
-                "# sigma2_post, exceedances, theta_max, theta_sigma=ret\n",
-                "# for r in ret:\n",
-                "# print(r.dtype)\n",
-                "# theta_max = jnp.array([0.1, 0.1, 0.1, 0.1])\n",
-                "# theta_m0 = theta_max - fi.mu_0\n",
-                "# theta_adj = theta_max + fi.logit_p1\n",
-                "# exp_theta_adj = jnp.exp(theta_adj)\n",
-                "# y = Y_I2\n",
-                "# n = N_I2\n",
-                "\n",
-                "# jax_opt()\n",
-                "acc\n"
+                "#     fast_loop=False,\n",
+                "# )\n"
             ]
         },
         {
             "cell_type": "code",
             "execution_count": 164,
             "metadata": {},
-            "outputs": [{
-                "data": {
-                    "text/plain": [
-                        "(array([[ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
-                        "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
-                        "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
-                        "        ...,\n",
-                        "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
-                        "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
-                        "        [ 1.,  1.,  1., ...,  1.,  1.,  1.]]),\n",
-                        " array([[        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
-                        "           8.5175151 ,   8.87252596],\n",
-                        "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
-                        "           8.5175151 ,   8.87252596],\n",
-                        "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
-                        "           8.5175151 ,   8.87252596],\n",
-                        "        ...,\n",
-                        "        [-15.78124253, -15.25253092, -14.32642149, ...,   1.32578601,\n",
-                        "           2.18722541,   2.42099027],\n",
-                        "        [-15.81360094, -15.28283245, -14.3575988 , ...,  -2.60645969,\n",
-                        "          -2.60283052,  -2.60188043],\n",
-                        "        [-15.83460559, -15.30497092, -14.383241  , ...,  -3.23427153,\n",
-                        "          -3.23251662,  -3.23205077]]))"
-                    ]
-                },
-                "execution_count": 164,
-                "metadata": {},
-                "output_type": "execute_result"
-            }],
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "(array([[ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
+                            "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
+                            "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
+                            "        ...,\n",
+                            "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+                            "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+                            "        [ 1.,  1.,  1., ...,  1.,  1.,  1.]]),\n",
+                            " array([[        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
+                            "           8.5175151 ,   8.87252596],\n",
+                            "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
+                            "           8.5175151 ,   8.87252596],\n",
+                            "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
+                            "           8.5175151 ,   8.87252596],\n",
+                            "        ...,\n",
+                            "        [-15.78124253, -15.25253092, -14.32642149, ...,   1.32578601,\n",
+                            "           2.18722541,   2.42099027],\n",
+                            "        [-15.81360094, -15.28283245, -14.3575988 , ...,  -2.60645969,\n",
+                            "          -2.60283052,  -2.60188043],\n",
+                            "        [-15.83460559, -15.30497092, -14.383241  , ...,  -3.23427153,\n",
+                            "          -3.23251662,  -3.23205077]]))"
+                        ]
+                    },
+                    "execution_count": 164,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
             "source": [
                 "with open(\"/home/const/imprint/out.txt\") as f:\n",
                 "    arr = np.array(eval(f.read()))\n",
                 "arr.shape\n",
-                "np.linalg.slogdet(arr)"
+                "np.linalg.slogdet(arr)\n"
             ]
         },
         {
             "cell_type": "code",
             "execution_count": 18,
             "metadata": {},
-            "outputs": [{
-                "name": "stdout",
-                "output_type": "stream",
-                "text": [
-                    "0.0010487821918949499\n",
-                    "[0.00074172 0.00074148]\n"
-                ]
-            }],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "0.0010487821918949499\n",
+                        "[0.00074172 0.00074148]\n"
+                    ]
+                }
+            ],
             "source": [
                 "# with jit:\n",
                 "x = np.array([2.3373992443084717, 2.337362289428711])\n",
@@ -279,20 +194,22 @@
             "cell_type": "code",
             "execution_count": 61,
             "metadata": {},
-            "outputs": [{
-                "name": "stdout",
-                "output_type": "stream",
-                "text": [
-                    "[[-6.37561     0.02439026  0.02439024  0.02439024]\n",
-                    " [ 0.02439026 -6.37561     0.02439026  0.02439025]\n",
-                    " [ 0.02439025  0.02439026 -6.37561     0.02439024]\n",
-                    " [ 0.02439025  0.02439025  0.02439024 -6.37561   ]]\n",
-                    "[[-0.1568547  -0.00060468 -0.00060468 -0.00060468]\n",
-                    " [-0.00060468 -0.15685467 -0.00060468 -0.00060468]\n",
-                    " [-0.00060468 -0.00060468 -0.15685469 -0.00060468]\n",
-                    " [-0.00060468 -0.00060468 -0.00060468 -0.15685469]]\n"
-                ]
-            }],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "[[-6.37561     0.02439026  0.02439024  0.02439024]\n",
+                        " [ 0.02439026 -6.37561     0.02439026  0.02439025]\n",
+                        " [ 0.02439025  0.02439026 -6.37561     0.02439024]\n",
+                        " [ 0.02439025  0.02439025  0.02439024 -6.37561   ]]\n",
+                        "[[-0.1568547  -0.00060468 -0.00060468 -0.00060468]\n",
+                        " [-0.00060468 -0.15685467 -0.00060468 -0.00060468]\n",
+                        " [-0.00060468 -0.00060468 -0.15685469 -0.00060468]\n",
+                        " [-0.00060468 -0.00060468 -0.00060468 -0.15685469]]\n"
+                    ]
+                }
+            ],
             "source": [
                 "def logit(x):\n",
                 "    return jnp.log(x) - jnp.log(1 - x)\n",
@@ -356,13 +273,15 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
-                "name": "stderr",
-                "output_type": "stream",
-                "text": [
-                    "100%|██████████| 3000/3000 [00:02<00:00, 1104.55it/s, init loss: 78.8034, avg. loss [2851-3000]: 19.7578]\n"
-                ]
-            }],
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "100%|██████████| 3000/3000 [00:02<00:00, 1104.55it/s, init loss: 78.8034, avg. loss [2851-3000]: 19.7578]\n"
+                    ]
+                }
+            ],
             "source": [
                 "import numpyro\n",
                 "from functools import partial\n",
@@ -394,7 +313,8 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "data": {
                         "text/plain": [
                             "[<matplotlib.lines.Line2D at 0x14dc2b910>]"
@@ -425,18 +345,20 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
-                "data": {
-                    "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlMAAAEvCAYAAABhSUTPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAaRklEQVR4nO3df4xd9Znf8fcTA+s6JYnXsKJiTGcsYynxujulNslqtQppjJdg2USpd8HVSqyKoGxicLPpNlAqlLqRvEksW6sZJhQ3SZUVLYEW05FsiuMttNtoja5t7ro1lNQ7yeIhGWXWNlR1ahI73/4xY3MZz4/jOefec++575eENPfe4zmPco3y4fk+5/uNlBKSJEman/eVXYAkSVInM0xJkiTlYJiSJEnKwTAlSZKUg2FKkiQpB8OUJElSDleUdeNrrrkm9fb2lnV7SZKkzA4fPvzXKaVrp/ustDDV29vLoUOHyrq9JElSZhHxVzN95jKfJElSDoYpSZKkHAxTkiRJOZQ2MyVJkqrp5z//OaOjo5w9e7bsUi7bwoUL6enp4corr8z8ZwxTkiSpUKOjo1x99dX09vYSEWWXk1lKiZMnTzI6OkpfX1/mP+cynyRJKtTZs2dZsmRJRwUpgIhgyZIll91RM0xJkqTCdVqQumA+dRumJEmScjBMSZIk5WCYkiRJlXT+/Hm2bt3KypUrWbVqFSMjI025j0/zSZKkptr13e8X+vs+f+uKTNdt376dZcuWcezYMXbv3s3Q0BA7duwotBawMyVJUscZHxgsu4S2d+bMGfbs2cPWrVsB6Ovr4/jx4025l50pSZJUOQcOHODEiRP09/cDcOrUKdauXduUe9mZkiRJlVOv19m2bRv1ep16vc66devo7+/nzJkz3H333dx77708+eSThdzLMCVJUgdwae/ynD59mkWLFgFw7tw59u/fz4YNG3j22WfZtGkTu3fvZnh4uJB7GaYkSepQ4wODhqwZrFixgoMHDwKwa9cu1q9fT19fH6OjoyxduhSABQsWFHIvw5QkSW1mqD50yXu1sRr7Hrnb8JTR5s2bOXLkCMuXL+fo0aPs3LkTgJ6eHkZHRwH4xS9+Uci9HECXJKkNDdWH+Gz/Z2f8/HJC1YVrr31gS+665iPrVgZFWrx48cXOVKPPfOYzbNmyhb1797Jhw4ZC7mWYkiRJXeP9738/3/rWtwr9nS7zSZIk5WCYkiSpAhxGL49hSpIkKQfDlCRJFTK1O2W3qvkMU5IklWS6LRCK4rJf6ximJEkq0VB9aMZQNdtnah+GKUmS2lTvMy/P68/ZkWot95mSJKlN7Hvkbn742x+95P2h+hC9rS9HGRmmJElqM1k7UrWxGmuuW2MnqmSZlvki4raIeD0ijkfEQ9N8fkNEvBgRr0TE0Yi4vfhSJUlSbax28R/N7vz582zdupWVK1eyatUqRkZGmnKfOTtTEbEAeAy4FRgFahExnFJ6teGyfwE8nVL6ekR8BNgHdiQlSRLw4vZif98nHs502fbt21m2bBnHjh1j9+7dDA0NsWPHjmJrIdsy383A8ZTSCEBEPAXcATSGqQR8YPLnDwI/KrJISZK6xXyHzvVeZ86cYc+ePRw+fBiAvr4+9u7d25R7ZQlT1wMnGl6PAlOn474E7I+IB4D3A2sLqU6SJGkeDhw4wIkTJ+jv7wfg1KlTrF3bnHhS1NYIm4F/m1LqAW4H/iQiLvndEXFfRByKiEPj4+MF3VqSpM6XZz8pZ6guVa/X2bZtG/V6nXq9zrp16+jv72dkZIR77rmHTZs2FXavLGHqTWBpw+ueyfca3QM8DZBS+nNgIXDN1F+UUnoipbQ6pbT62muvnV/FkiRJczh9+jSLFi0C4Ny5c+zfv58NGzawbNkyvvGNbxR6ryxhqgbcGBF9EXEVcBcwPOWaN4BPAkTEh5kIU7aeJEnKqfeZl52jmocVK1Zw8OBBAHbt2sX69evp6+tryr3mDFMppXPAFuAF4DUmnto7FhHbImLj5GVfAO6NiL8A/j3weyml1JSKJUnqQB4N01qbN2/myJEjLF++nKNHj7Jz586m3SvTpp0ppX1MbHfQ+N6jDT+/CvxGsaVJklRNZYWq8YFBrn1gS+tvnHErgyItXrz4Ymeq0cmTJ3nkkUd45ZVX2L59Ow8/nL82d0CXJEldY8mSJTz++OOF/k4POpYkScrBMCVJUgdr3BLhcrZH8Dy/4himJElqIYfQq8cwJUmSlINhSpKkJrITVX2GKUmSpBwMU5IkSTkYpiRJKlHRR8V46HHrGaYkSZJyMExJklRBdqfg/PnzbN26lZUrV7Jq1SpGRkaach+Pk5EkqQna9Sm+MjbrLPp/i8/2fzbTddu3b2fZsmUcO3aM3bt3MzQ0xI4dOwqtBQxTkiSVrui5KcGZM2fYs2cPhw8fBqCvr4+9e/c25V6GKUmSVDkHDhzgxIkT9Pf3A3Dq1CnWrl3blHs5MyVJkiqnXq+zbds26vU69XqddevW0d/fz3PPPce9997LnXfeyf79+wu5l2FKkiRVzunTp1m0aBEA586dY//+/WzYsIFPf/rT7N69m8cff5zvfOc7hdzLMCVJkipnxYoVHDx4EIBdu3axfv16+vr6Ln7+5S9/mc997nOF3MswJUlSlyrjyb5W2bx5M0eOHGH58uUcPXqUnTt3ApBS4otf/CKf+tSnuOmmmwq5lwPokiSVoJue4Mu6lUGRFi9efLEz1WhgYIADBw7w9ttvc/z4ce6///7c9zJMSZLUZO2651Q3evDBB3nwwQcL/Z0u80mSJOVgZ0qSpC7WODd17QNbSqykc9mZkiSpompjNc/oawHDlCRJLdL7zMtdNXjeLQxTkiS1mIGqWgxTkiQVzKf3uothSpKkinNuqrkMU5IkSTkYpiRJEjCxTUKVjpg5f/48W7duZeXKlaxatYqRkZGm3Md9piRJUlMVHdCy7oe1fft2li1bxrFjx9i9ezdDQ0Ps2LGj0FrAMCVJkirozJkz7Nmzh8OHDwPQ19fH3r17m3Ivw5QkSQWZ7Sk+t0NorQMHDnDixAn6+/sBOHXqFGvXrm3KvZyZkiRJlVOv19m2bRv1ep16vc66devo7+/ntdde4/7772fTpk18/etfL+RehilJklQ5p0+fZtGiRQCcO3eO/fv3s2HDBj784Q/z+OOP8/TTT/O9732vkHsZpiRJUuWsWLGCgwcPArBr1y7Wr19PX18fAMPDw6xfv57bb7+9kHsZpiRJKoC7nreXzZs3c+TIEZYvX87Ro0fZuXPnxc82btzI888/z5NPPlnIvRxAlyRJTZV1K4MiLV68+GJnqtFLL73Es88+yzvvvFNYZ8owJUmSusYtt9zCLbfcUujvdJlPkqQuUBureUZfk9iZkiQpB2elZGdKkiQpB8OUJElN0vvMy+583gUMU5IkqXAppbJLmJf51G2YkiRJhVq4cCEnT57suECVUuLkyZMsXLjwsv6cA+iSJM1TlYfPxwcGgfntEdXT08Po6Cjj4+NFl9V0CxcupKen57L+jGFKkqQm67a5qSuvvPLi0S3dwGU+SZL0Hhe6UsrGMCVJUpdx885iGaYkSZJyMExJktRF7EoVzzAlSZKUQ6YwFRG3RcTrEXE8Ih6a4ZrfiYhXI+JYRPy7YsuUJElqT3NujRARC4DHgFuBUaAWEcMppVcbrrkReBj4jZTS6Yj4lWYVLElSJ+i27RC6WZbO1M3A8ZTSSErpZ8BTwB1TrrkXeCyldBogpfSTYsuUJEllcJuEuWUJU9cDJxpej06+12gFsCIivhcRByPitqIKlCRJamdF7YB+BXAjcAvQA/y3iFiVUnqr8aKIuA+4D+CGG24o6NaSJEnlyRKm3gSWNrzumXyv0Sjwckrp58APIuL7TISr9zx/mVJ6AngCYPXq1Z11+qEkSZOqfCafLl+WZb4acGNE9EXEVcBdwPCUa55joitFRFzDxLLfSHFlSpIktac5w1RK6RywBXgBeA14OqV0LCK2RcTGycteAE5GxKvAi8AfppRONqtoSZKkdpFpZiqltA/YN+W9Rxt+TsAfTP4jSZLUNdwBXZIkKQfDlCRJGVVp8Lw2VvOcvoIYpiRJknIwTEmSJOVgmJIk6TJUaakPcKmvAIYpSZKkHAxTkiQVpPeZl8suQSUo6mw+SZKEgaob2ZmSJEnKwTAlSZJmNT4wWHYJbc1lPkmS5lC1J/hULDtTkiRJORimJEkqgIPn3cswJUmSlINhSpIkzWl8YNBB9Bk4gC5J0izmGj6vwvLehSNl1ly3puRKOpOdKUmSpBwMU5IkSTkYpiRJUmbOTV3KMCVJkpSDYUqSJCkHn+aTJGka3XiETG2s5hN982BnSpIkKQfDlCRJUg6GKUmSpBwMU5IkSTkYpiRJknIwTEmSJOVgmJIkaZ6qcMix8jNMSZIk5WCYkiRJysEwJUmSLsv4wKAHHjcwTEmSJOVgmJIkScrBMCVJki6qjdWojdXKLqOjGKYkSZpiqD5UdgnqIIYpSZKkHK4ouwBJkjqJG3VqKsOUJEmTXN7TfLjMJ0ma2Yvb3/1HmsK9piYYpiRJknIwTEmSJOXgzJQkdaPGZbtPPFxeHVIFGKYkqdvNJ1hNnaEykFVObazGmuvWlF1GR3CZT5IkKQc7U5LUDZr9NJ7LhupihilJ0rvcAkG6bC7zSZIk5WBnSpKUzXy6Vg6qqwsYpiSpSlymk1ou0zJfRNwWEa9HxPGIeGiW6/5BRKSIWF1ciZIkSe1rzs5URCwAHgNuBUaBWkQMp5RenXLd1cBWwOO0JambzdYd86m/jlIbqwG439QcsnSmbgaOp5RGUko/A54C7pjmun8FfAU4W2B9kiS1xFB9qOwS1KGyzExdD5xoeD0KfLTxgoi4CViaUtobEX9YYH2SJLWF3mdceNH0cm+NEBHvA3YCX8hw7X0RcSgiDo2Pj+e9tSRJKtn4wGDZJZQuS2fqTWBpw+ueyfcuuBr4VeCliAC4DhiOiI0ppUONvyil9ATwBMDq1atTjrolSZ3O+SlVRJYwVQNujIg+JkLUXcA/vPBhSult4JoLryPiJeCfTg1SkqSCuP2B1FbmXOZLKZ0DtgAvAK8BT6eUjkXEtojY2OwCJUlSexsfGOzq5b5Mm3amlPYB+6a89+gM196SvyxJkqTO4Nl8kiTNwSf5NBvDlCRJUg6ezSdJGez67vcvee/zt64ooRIVzc06lZdhSpKmmC44lc4n+KS2ZZiS1DWK7i7ZrSrQbGHRPajU5gxTkiqpLbtLkirJAXRJkqQc7ExJ6mqt6GDNdI9ZlwSdkVIbqY3VWHPdmrLLaFuGKUkqUK5wZoCSOpLLfJKk9vbi9nf/KZBbIqgohilJkqQcXOaTpJJMXRL82Bsn+fVlS0qqpjvZncrOuamZ2ZmSJGkWnsunudiZkqQW+tgbT7zn9cEb7iupEklFMUxJkjrH1CF0d0dXGzBMSVKJpnaqdJkaw1XGYOWclIpmmJLU8ap0dMyfj5y85D2H0qX2ZpiS1FGqFJykqhkfGOTaB7aUXUbL+TSfJElSDnamJEmahlsiKCvDlCQ1mUPmUrW5zCdJkjKpjdWojdXKLqPt2JmS1LYcNp/gE35Se7MzJUmSlIOdKUltwS6UWsENO9UMdqYkSZJysDMlSU3gE3wlmMfRMlIRDFOSWs4lvfwcSm8u95jS5XCZT5IkFWZ8YJDxgcGyy2gpO1OSJE2yI5VNbazGmuvWlF1G2zBMSVIBnJFqM43zU8DQ4g+WVIi6gct8kiRJORimJEmScnCZT1JT+eRe6/iEn1QOw5QkzZNzUpLAZT5JkqRcDFOSJEk5uMwnSZfBpT1pQm2sBjDjflPjA4Nc+8CWVpZUGjtTkqRKG3rraNklqOIMU5IkSTm4zCepMG6DoLb1gz979+e+35z2Eo+S0XzZmZIkScrBMCVJkpSDy3yS5sUlvc7grujTyLDkp2KMDwwCVP6pPsOUJM3CrRAkzcUwJUldxm7Vezl4rrycmZIkSfN2YfPObmZnStKcum0+yqW9anCzTrWKYUqSMEBJmj+X+SRJknKwMyVJqpzMS3w/+DN468fvvv7Q325OQaq0TJ2piLgtIl6PiOMR8dA0n/9BRLwaEUcj4k8jwr+NkiSpK8zZmYqIBcBjwK3AKFCLiOGU0qsNl70CrE4p/TQifh/4KnBnMwqW1FzdNmwuSXllWea7GTieUhoBiIingDuAi2EqpfRiw/UHgd8tskhJKpoD5+o98GN+uPZvlV2GKiDLMt/1wImG16OT783kHuD56T6IiPsi4lBEHBofH89epSRJTdB74MdzXyTNodAB9Ij4XWA18PHpPk8pPQE8AbB69epU5L0lSfPnruiT3vqrd392GL0w4wODlT6fL0uYehNY2vC6Z/K994iItcAjwMdTSu8UU56kZnI+SpLyy7LMVwNujIi+iLgKuAsYbrwgIv4u8K+BjSmlnxRfpiRJUnuaszOVUjoXEVuAF4AFwDdTSsciYhtwKKU0DHwN+JvAMxEB8EZKaWMT65Yk6RIeIaMyZJqZSintA/ZNee/Rhp/XFlyXJBXOJ/ik5rhw2PGa69aUXEk53AFdkjQth9KlbAxTkirNbpTUHqr8RJ9hSuoSPrknXSa3SVBGmc7mkySp3Tl8rrLYmZIqyC6UNDN3PVfRDFOSJM2lcckPXPbTeximJFWKA+dSeWpjta7cHsEwJanjGaBax+0SpEs5gC5JkpSDYUqSJCkHl/mkDtetT+65tCd1nvGBQYDKbd5pZ0qSJCkHw5QkSVIOLvNJHaRbl/Skubj7ucpkmJLUEZyRal9ul6Bu5zKfJKlreJSMmsEwJUmSClMbq1Ebq5VdRku5zCdJqrzCO1KNZ/V5Tl/XM0xJbcphc2luDp6rHRimpDZgcJqeQ+fqCI1dKrBT1YUMU1KLGZzUDXzCTxfmptZct+aSz8YHBiu1C7phSlJbsRslqdMYpqQmsgslSdVnmJJUKjtRaraW7y3lk35dx32mJEmScrAzJRXEJT1pdkUPpWfZFsEdz9UKhilJLefSnqQqMUxJktQszk/NaHxgEKASWyQYpqQG0y3Vff7WFSVUImkm7nqudmOYkubgLJQkzd9sm3dWhWFKXcuQ1FrOSUmaThV2QzdMSWoKw5OyaNaxMz7Fp1YyTKkr2IWSOsdsAauj56U8ELmy3LRTkiQpBztTqhy7UOVxaU9SNzJMqaMZnMpngFK7cV6q83T6nlOGKUlS2+voWSlVnmFKHcMuVHuwE6UynHjr/13y3tIP/Y0SKimQu6NXhmFKLZV1h3GDU3sxQEnKqzZWq+zGnYYplc7gJEmCzt3A0zAlaVp2o9RpOnrwvEuW/Kp6tIxhShJgeJKk+TJMqRAu1UlqluH3HZ/2/alD6b989hwfWOj/ran1/Funy2ZwktRufu2//zUA/+fsuUs+67iA1eXHznTi3FSH/Q1TqxmcJElFq9qTfYYpXWRw6g7ORqlTzLS8d7kq0a1SW/NvU5cyOHUPw5Oq6sLSnjrTbE/2ddrxMoapLmBw6j4GKGl2HdWtmjpDdUFFZqmqsOTXpn9zNF8Gp+5lgFJVFLW8J7WKYapDGJI0leFJ3awZS3wd1a2CSj31N9OSX6c82Zfpb0lE3Ab8MbAA+DcppT+a8vkvAd8G/h5wErgzpfTDYkuVJHW7Vs9JTRewptPWoUtNN+e3HxELgMeAW4FRoBYRwymlVxsuuwc4nVJaHhF3AV8B7mxGwVVjx0lzsQMlKZMKzFbNNj/Vzl2qLFH6ZuB4SmkEICKeAu4AGsPUHcCXJn/+D8BgRERKKRVYa8czOKlRY0g6eMN9074vdYvZ5qQ64am9jlsibGNTA9WFJ/vaWZZv+nrgRMPrUeCjM12TUjoXEW8DS4D2/zfgMhmINJv5BiEDlLrJXAPmnRCessi6RJhV1nB2yX3H/jJ/sGtxd6txhqrx58Zg1U5dqpbG5oi4D7jwn+D/NyJeb+X928w1VDBsdim/y2rwe6wOv8vK+HbDd/nt93704AOtLmbGRJklTL0JLG143TP53nTXjEbEFcAHmRhEf4+U0hOA/wkORMShlNLqsutQfn6X1eD3WB1+l9XRKd/l+zJcUwNujIi+iLgKuAsYnnLNMHD35M+bgP/ivJQkSeoGc3amJmegtgAvMLE1wjdTSsciYhtwKKU0DHwD+JOIOA6cYiJwSZIkVV6mmamU0j5g35T3Hm34+Szw28WWVnkud1aH32U1+D1Wh99ldXTEdxmuxkmSJM1flpkpSZIkzcAwVaKI6I+IgxFRj4hDEXFz2TVpfiLigYj4XxFxLCK+WnY9yicivhARKSKuKbsWzU9EfG3y38mjEbEnIj5Udk3KLiJui4jXI+J4RDxUdj1zMUyV66vAv0wp9QOPTr5Wh4mITzBxCsCvpZRWAjtKLkk5RMRSYB3wRtm1KJfvAr+aUvo7wPeBh0uuRxk1HGP3KeAjwOaI+Ei5Vc3OMFWuBHxg8ucPAj8qsRbN3+8Df5RSegcgpfSTkutRPruAf8bEv5/qUCml/SmlC1uBH2Rij0R1hovH2KWUfgZcOMaubRmmyvVPgK9FxAkmuhn+l1NnWgH8ZkS8HBH/NSKmP6VTbS8i7gDeTCn9Rdm1qFD/CHi+7CKU2XTH2F1fUi2ZeApjk0XEAeC6aT56BPgk8PmU0n+MiN9hYr+uta2sT9nM8T1eAfwy8DFgDfB0RCxz49r2NMd3+c+ZWOJTB5jtu0wp/afJax4BzgFPtrI2dRe3RijR5IHQH0oppYgI4O2U0gfm+nNqLxHxn4GvpJRenHz9l8DHUkrj5VamyxERq4A/BX46+VYPE0vvN6eUxkorTPMWEb8H/GPgkymln85xudpERPw68KWU0m9Nvn4YIKW0vdTCZuEyX7l+BHx88ue/D/zvEmvR/D0HfAIgIlYAV+Ehqx0npfQ/Ukq/klLqTSn1MrG0cJNBqjNFxG1MzL5tNEh1nCzH2LUVl/nKdS/wx5OHQ58F7iu5Hs3PN4FvRsT/BH4G3O0Sn1S6QeCXgO9ONP45mFK6v9ySlMVMx9iVXNasXOaTJEnKwWU+SZKkHAxTkiRJORimJEmScjBMSZIk5WCYkiRJysEwJUmSlINhSpIkKQfDlCRJUg7/H3E6s99vVsI1AAAAAElFTkSuQmCC",
-                    "text/plain": [
-                        "<Figure size 720x360 with 1 Axes>"
-                    ]
-                },
-                "metadata": {
-                    "needs_background": "light"
-                },
-                "output_type": "display_data"
-            }],
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlMAAAEvCAYAAABhSUTPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAaRklEQVR4nO3df4xd9Znf8fcTA+s6JYnXsKJiTGcsYynxujulNslqtQppjJdg2USpd8HVSqyKoGxicLPpNlAqlLqRvEksW6sZJhQ3SZUVLYEW05FsiuMttNtoja5t7ro1lNQ7yeIhGWXWNlR1ahI73/4xY3MZz4/jOefec++575eENPfe4zmPco3y4fk+5/uNlBKSJEman/eVXYAkSVInM0xJkiTlYJiSJEnKwTAlSZKUg2FKkiQpB8OUJElSDleUdeNrrrkm9fb2lnV7SZKkzA4fPvzXKaVrp/ustDDV29vLoUOHyrq9JElSZhHxVzN95jKfJElSDoYpSZKkHAxTkiRJOZQ2MyVJkqrp5z//OaOjo5w9e7bsUi7bwoUL6enp4corr8z8ZwxTkiSpUKOjo1x99dX09vYSEWWXk1lKiZMnTzI6OkpfX1/mP+cynyRJKtTZs2dZsmRJRwUpgIhgyZIll91RM0xJkqTCdVqQumA+dRumJEmScjBMSZIk5WCYkiRJlXT+/Hm2bt3KypUrWbVqFSMjI025j0/zSZKkptr13e8X+vs+f+uKTNdt376dZcuWcezYMXbv3s3Q0BA7duwotBawMyVJUscZHxgsu4S2d+bMGfbs2cPWrVsB6Ovr4/jx4025l50pSZJUOQcOHODEiRP09/cDcOrUKdauXduUe9mZkiRJlVOv19m2bRv1ep16vc66devo7+/nzJkz3H333dx77708+eSThdzLMCVJUgdwae/ynD59mkWLFgFw7tw59u/fz4YNG3j22WfZtGkTu3fvZnh4uJB7GaYkSepQ4wODhqwZrFixgoMHDwKwa9cu1q9fT19fH6OjoyxduhSABQsWFHIvw5QkSW1mqD50yXu1sRr7Hrnb8JTR5s2bOXLkCMuXL+fo0aPs3LkTgJ6eHkZHRwH4xS9+Uci9HECXJKkNDdWH+Gz/Z2f8/HJC1YVrr31gS+665iPrVgZFWrx48cXOVKPPfOYzbNmyhb1797Jhw4ZC7mWYkiRJXeP9738/3/rWtwr9nS7zSZIk5WCYkiSpAhxGL49hSpIkKQfDlCRJFTK1O2W3qvkMU5IklWS6LRCK4rJf6ximJEkq0VB9aMZQNdtnah+GKUmS2lTvMy/P68/ZkWot95mSJKlN7Hvkbn742x+95P2h+hC9rS9HGRmmJElqM1k7UrWxGmuuW2MnqmSZlvki4raIeD0ijkfEQ9N8fkNEvBgRr0TE0Yi4vfhSJUlSbax28R/N7vz582zdupWVK1eyatUqRkZGmnKfOTtTEbEAeAy4FRgFahExnFJ6teGyfwE8nVL6ekR8BNgHdiQlSRLw4vZif98nHs502fbt21m2bBnHjh1j9+7dDA0NsWPHjmJrIdsy383A8ZTSCEBEPAXcATSGqQR8YPLnDwI/KrJISZK6xXyHzvVeZ86cYc+ePRw+fBiAvr4+9u7d25R7ZQlT1wMnGl6PAlOn474E7I+IB4D3A2sLqU6SJGkeDhw4wIkTJ+jv7wfg1KlTrF3bnHhS1NYIm4F/m1LqAW4H/iQiLvndEXFfRByKiEPj4+MF3VqSpM6XZz8pZ6guVa/X2bZtG/V6nXq9zrp16+jv72dkZIR77rmHTZs2FXavLGHqTWBpw+ueyfca3QM8DZBS+nNgIXDN1F+UUnoipbQ6pbT62muvnV/FkiRJczh9+jSLFi0C4Ny5c+zfv58NGzawbNkyvvGNbxR6ryxhqgbcGBF9EXEVcBcwPOWaN4BPAkTEh5kIU7aeJEnKqfeZl52jmocVK1Zw8OBBAHbt2sX69evp6+tryr3mDFMppXPAFuAF4DUmnto7FhHbImLj5GVfAO6NiL8A/j3weyml1JSKJUnqQB4N01qbN2/myJEjLF++nKNHj7Jz586m3SvTpp0ppX1MbHfQ+N6jDT+/CvxGsaVJklRNZYWq8YFBrn1gS+tvnHErgyItXrz4Ymeq0cmTJ3nkkUd45ZVX2L59Ow8/nL82d0CXJEldY8mSJTz++OOF/k4POpYkScrBMCVJUgdr3BLhcrZH8Dy/4himJElqIYfQq8cwJUmSlINhSpKkJrITVX2GKUmSpBwMU5IkSTkYpiRJKlHRR8V46HHrGaYkSZJyMExJklRBdqfg/PnzbN26lZUrV7Jq1SpGRkaach+Pk5EkqQna9Sm+MjbrLPp/i8/2fzbTddu3b2fZsmUcO3aM3bt3MzQ0xI4dOwqtBQxTkiSVrui5KcGZM2fYs2cPhw8fBqCvr4+9e/c25V6GKUmSVDkHDhzgxIkT9Pf3A3Dq1CnWrl3blHs5MyVJkiqnXq+zbds26vU69XqddevW0d/fz3PPPce9997LnXfeyf79+wu5l2FKkiRVzunTp1m0aBEA586dY//+/WzYsIFPf/rT7N69m8cff5zvfOc7hdzLMCVJkipnxYoVHDx4EIBdu3axfv16+vr6Ln7+5S9/mc997nOF3MswJUlSlyrjyb5W2bx5M0eOHGH58uUcPXqUnTt3ApBS4otf/CKf+tSnuOmmmwq5lwPokiSVoJue4Mu6lUGRFi9efLEz1WhgYIADBw7w9ttvc/z4ce6///7c9zJMSZLUZO2651Q3evDBB3nwwQcL/Z0u80mSJOVgZ0qSpC7WODd17QNbSqykc9mZkiSpompjNc/oawHDlCRJLdL7zMtdNXjeLQxTkiS1mIGqWgxTkiQVzKf3uothSpKkinNuqrkMU5IkSTkYpiRJEjCxTUKVjpg5f/48W7duZeXKlaxatYqRkZGm3Md9piRJUlMVHdCy7oe1fft2li1bxrFjx9i9ezdDQ0Ps2LGj0FrAMCVJkirozJkz7Nmzh8OHDwPQ19fH3r17m3Ivw5QkSQWZ7Sk+t0NorQMHDnDixAn6+/sBOHXqFGvXrm3KvZyZkiRJlVOv19m2bRv1ep16vc66devo7+/ntdde4/7772fTpk18/etfL+RehilJklQ5p0+fZtGiRQCcO3eO/fv3s2HDBj784Q/z+OOP8/TTT/O9732vkHsZpiRJUuWsWLGCgwcPArBr1y7Wr19PX18fAMPDw6xfv57bb7+9kHsZpiRJKoC7nreXzZs3c+TIEZYvX87Ro0fZuXPnxc82btzI888/z5NPPlnIvRxAlyRJTZV1K4MiLV68+GJnqtFLL73Es88+yzvvvFNYZ8owJUmSusYtt9zCLbfcUujvdJlPkqQuUBureUZfk9iZkiQpB2elZGdKkiQpB8OUJElN0vvMy+583gUMU5IkqXAppbJLmJf51G2YkiRJhVq4cCEnT57suECVUuLkyZMsXLjwsv6cA+iSJM1TlYfPxwcGgfntEdXT08Po6Cjj4+NFl9V0CxcupKen57L+jGFKkqQm67a5qSuvvPLi0S3dwGU+SZL0Hhe6UsrGMCVJUpdx885iGaYkSZJyMExJktRF7EoVzzAlSZKUQ6YwFRG3RcTrEXE8Ih6a4ZrfiYhXI+JYRPy7YsuUJElqT3NujRARC4DHgFuBUaAWEcMppVcbrrkReBj4jZTS6Yj4lWYVLElSJ+i27RC6WZbO1M3A8ZTSSErpZ8BTwB1TrrkXeCyldBogpfSTYsuUJEllcJuEuWUJU9cDJxpej06+12gFsCIivhcRByPitqIKlCRJamdF7YB+BXAjcAvQA/y3iFiVUnqr8aKIuA+4D+CGG24o6NaSJEnlyRKm3gSWNrzumXyv0Sjwckrp58APIuL7TISr9zx/mVJ6AngCYPXq1Z11+qEkSZOqfCafLl+WZb4acGNE9EXEVcBdwPCUa55joitFRFzDxLLfSHFlSpIktac5w1RK6RywBXgBeA14OqV0LCK2RcTGycteAE5GxKvAi8AfppRONqtoSZKkdpFpZiqltA/YN+W9Rxt+TsAfTP4jSZLUNdwBXZIkKQfDlCRJGVVp8Lw2VvOcvoIYpiRJknIwTEmSJOVgmJIk6TJUaakPcKmvAIYpSZKkHAxTkiQVpPeZl8suQSUo6mw+SZKEgaob2ZmSJEnKwTAlSZJmNT4wWHYJbc1lPkmS5lC1J/hULDtTkiRJORimJEkqgIPn3cswJUmSlINhSpIkzWl8YNBB9Bk4gC5J0izmGj6vwvLehSNl1ly3puRKOpOdKUmSpBwMU5IkSTkYpiRJUmbOTV3KMCVJkpSDYUqSJCkHn+aTJGka3XiETG2s5hN982BnSpIkKQfDlCRJUg6GKUmSpBwMU5IkSTkYpiRJknIwTEmSJOVgmJIkaZ6qcMix8jNMSZIk5WCYkiRJysEwJUmSLsv4wKAHHjcwTEmSJOVgmJIkScrBMCVJki6qjdWojdXKLqOjGKYkSZpiqD5UdgnqIIYpSZKkHK4ouwBJkjqJG3VqKsOUJEmTXN7TfLjMJ0ma2Yvb3/1HmsK9piYYpiRJknIwTEmSJOXgzJQkdaPGZbtPPFxeHVIFGKYkqdvNJ1hNnaEykFVObazGmuvWlF1GR3CZT5IkKQc7U5LUDZr9NJ7LhupihilJ0rvcAkG6bC7zSZIk5WBnSpKUzXy6Vg6qqwsYpiSpSlymk1ou0zJfRNwWEa9HxPGIeGiW6/5BRKSIWF1ciZIkSe1rzs5URCwAHgNuBUaBWkQMp5RenXLd1cBWwOO0JambzdYd86m/jlIbqwG439QcsnSmbgaOp5RGUko/A54C7pjmun8FfAU4W2B9kiS1xFB9qOwS1KGyzExdD5xoeD0KfLTxgoi4CViaUtobEX9YYH2SJLWF3mdceNH0cm+NEBHvA3YCX8hw7X0RcSgiDo2Pj+e9tSRJKtn4wGDZJZQuS2fqTWBpw+ueyfcuuBr4VeCliAC4DhiOiI0ppUONvyil9ATwBMDq1atTjrolSZ3O+SlVRJYwVQNujIg+JkLUXcA/vPBhSult4JoLryPiJeCfTg1SkqSCuP2B1FbmXOZLKZ0DtgAvAK8BT6eUjkXEtojY2OwCJUlSexsfGOzq5b5Mm3amlPYB+6a89+gM196SvyxJkqTO4Nl8kiTNwSf5NBvDlCRJUg6ezSdJGez67vcvee/zt64ooRIVzc06lZdhSpKmmC44lc4n+KS2ZZiS1DWK7i7ZrSrQbGHRPajU5gxTkiqpLbtLkirJAXRJkqQc7ExJ6mqt6GDNdI9ZlwSdkVIbqY3VWHPdmrLLaFuGKUkqUK5wZoCSOpLLfJKk9vbi9nf/KZBbIqgohilJkqQcXOaTpJJMXRL82Bsn+fVlS0qqpjvZncrOuamZ2ZmSJGkWnsunudiZkqQW+tgbT7zn9cEb7iupEklFMUxJkjrH1CF0d0dXGzBMSVKJpnaqdJkaw1XGYOWclIpmmJLU8ap0dMyfj5y85D2H0qX2ZpiS1FGqFJykqhkfGOTaB7aUXUbL+TSfJElSDnamJEmahlsiKCvDlCQ1mUPmUrW5zCdJkjKpjdWojdXKLqPt2JmS1LYcNp/gE35Se7MzJUmSlIOdKUltwS6UWsENO9UMdqYkSZJysDMlSU3gE3wlmMfRMlIRDFOSWs4lvfwcSm8u95jS5XCZT5IkFWZ8YJDxgcGyy2gpO1OSJE2yI5VNbazGmuvWlF1G2zBMSVIBnJFqM43zU8DQ4g+WVIi6gct8kiRJORimJEmScnCZT1JT+eRe6/iEn1QOw5QkzZNzUpLAZT5JkqRcDFOSJEk5uMwnSZfBpT1pQm2sBjDjflPjA4Nc+8CWVpZUGjtTkqRKG3rraNklqOIMU5IkSTm4zCepMG6DoLb1gz979+e+35z2Eo+S0XzZmZIkScrBMCVJkpSDy3yS5sUlvc7grujTyLDkp2KMDwwCVP6pPsOUJM3CrRAkzcUwJUldxm7Vezl4rrycmZIkSfN2YfPObmZnStKcum0+yqW9anCzTrWKYUqSMEBJmj+X+SRJknKwMyVJqpzMS3w/+DN468fvvv7Q325OQaq0TJ2piLgtIl6PiOMR8dA0n/9BRLwaEUcj4k8jwr+NkiSpK8zZmYqIBcBjwK3AKFCLiOGU0qsNl70CrE4p/TQifh/4KnBnMwqW1FzdNmwuSXllWea7GTieUhoBiIingDuAi2EqpfRiw/UHgd8tskhJKpoD5+o98GN+uPZvlV2GKiDLMt/1wImG16OT783kHuD56T6IiPsi4lBEHBofH89epSRJTdB74MdzXyTNodAB9Ij4XWA18PHpPk8pPQE8AbB69epU5L0lSfPnruiT3vqrd392GL0w4wODlT6fL0uYehNY2vC6Z/K994iItcAjwMdTSu8UU56kZnI+SpLyy7LMVwNujIi+iLgKuAsYbrwgIv4u8K+BjSmlnxRfpiRJUnuaszOVUjoXEVuAF4AFwDdTSsciYhtwKKU0DHwN+JvAMxEB8EZKaWMT65Yk6RIeIaMyZJqZSintA/ZNee/Rhp/XFlyXJBXOJ/ik5rhw2PGa69aUXEk53AFdkjQth9KlbAxTkirNbpTUHqr8RJ9hSuoSPrknXSa3SVBGmc7mkySp3Tl8rrLYmZIqyC6UNDN3PVfRDFOSJM2lcckPXPbTeximJFWKA+dSeWpjta7cHsEwJanjGaBax+0SpEs5gC5JkpSDYUqSJCkHl/mkDtetT+65tCd1nvGBQYDKbd5pZ0qSJCkHw5QkSVIOLvNJHaRbl/Skubj7ucpkmJLUEZyRal9ul6Bu5zKfJKlreJSMmsEwJUmSClMbq1Ebq5VdRku5zCdJqrzCO1KNZ/V5Tl/XM0xJbcphc2luDp6rHRimpDZgcJqeQ+fqCI1dKrBT1YUMU1KLGZzUDXzCTxfmptZct+aSz8YHBiu1C7phSlJbsRslqdMYpqQmsgslSdVnmJJUKjtRaraW7y3lk35dx32mJEmScrAzJRXEJT1pdkUPpWfZFsEdz9UKhilJLefSnqQqMUxJktQszk/NaHxgEKASWyQYpqQG0y3Vff7WFSVUImkm7nqudmOYkubgLJQkzd9sm3dWhWFKXcuQ1FrOSUmaThV2QzdMSWoKw5OyaNaxMz7Fp1YyTKkr2IWSOsdsAauj56U8ELmy3LRTkiQpBztTqhy7UOVxaU9SNzJMqaMZnMpngFK7cV6q83T6nlOGKUlS2+voWSlVnmFKHcMuVHuwE6UynHjr/13y3tIP/Y0SKimQu6NXhmFKLZV1h3GDU3sxQEnKqzZWq+zGnYYplc7gJEmCzt3A0zAlaVp2o9RpOnrwvEuW/Kp6tIxhShJgeJKk+TJMqRAu1UlqluH3HZ/2/alD6b989hwfWOj/ran1/Funy2ZwktRufu2//zUA/+fsuUs+67iA1eXHznTi3FSH/Q1TqxmcJElFq9qTfYYpXWRw6g7ORqlTzLS8d7kq0a1SW/NvU5cyOHUPw5Oq6sLSnjrTbE/2ddrxMoapLmBw6j4GKGl2HdWtmjpDdUFFZqmqsOTXpn9zNF8Gp+5lgFJVFLW8J7WKYapDGJI0leFJ3awZS3wd1a2CSj31N9OSX6c82Zfpb0lE3Ab8MbAA+DcppT+a8vkvAd8G/h5wErgzpfTDYkuVJHW7Vs9JTRewptPWoUtNN+e3HxELgMeAW4FRoBYRwymlVxsuuwc4nVJaHhF3AV8B7mxGwVVjx0lzsQMlKZMKzFbNNj/Vzl2qLFH6ZuB4SmkEICKeAu4AGsPUHcCXJn/+D8BgRERKKRVYa8czOKlRY0g6eMN9074vdYvZ5qQ64am9jlsibGNTA9WFJ/vaWZZv+nrgRMPrUeCjM12TUjoXEW8DS4D2/zfgMhmINJv5BiEDlLrJXAPmnRCessi6RJhV1nB2yX3H/jJ/sGtxd6txhqrx58Zg1U5dqpbG5oi4D7jwn+D/NyJeb+X928w1VDBsdim/y2rwe6wOv8vK+HbDd/nt93704AOtLmbGRJklTL0JLG143TP53nTXjEbEFcAHmRhEf4+U0hOA/wkORMShlNLqsutQfn6X1eD3WB1+l9XRKd/l+zJcUwNujIi+iLgKuAsYnnLNMHD35M+bgP/ivJQkSeoGc3amJmegtgAvMLE1wjdTSsciYhtwKKU0DHwD+JOIOA6cYiJwSZIkVV6mmamU0j5g35T3Hm34+Szw28WWVnkud1aH32U1+D1Wh99ldXTEdxmuxkmSJM1flpkpSZIkzcAwVaKI6I+IgxFRj4hDEXFz2TVpfiLigYj4XxFxLCK+WnY9yicivhARKSKuKbsWzU9EfG3y38mjEbEnIj5Udk3KLiJui4jXI+J4RDxUdj1zMUyV66vAv0wp9QOPTr5Wh4mITzBxCsCvpZRWAjtKLkk5RMRSYB3wRtm1KJfvAr+aUvo7wPeBh0uuRxk1HGP3KeAjwOaI+Ei5Vc3OMFWuBHxg8ucPAj8qsRbN3+8Df5RSegcgpfSTkutRPruAf8bEv5/qUCml/SmlC1uBH2Rij0R1hovH2KWUfgZcOMaubRmmyvVPgK9FxAkmuhn+l1NnWgH8ZkS8HBH/NSKmP6VTbS8i7gDeTCn9Rdm1qFD/CHi+7CKU2XTH2F1fUi2ZeApjk0XEAeC6aT56BPgk8PmU0n+MiN9hYr+uta2sT9nM8T1eAfwy8DFgDfB0RCxz49r2NMd3+c+ZWOJTB5jtu0wp/afJax4BzgFPtrI2dRe3RijR5IHQH0oppYgI4O2U0gfm+nNqLxHxn4GvpJRenHz9l8DHUkrj5VamyxERq4A/BX46+VYPE0vvN6eUxkorTPMWEb8H/GPgkymln85xudpERPw68KWU0m9Nvn4YIKW0vdTCZuEyX7l+BHx88ue/D/zvEmvR/D0HfAIgIlYAV+Ehqx0npfQ/Ukq/klLqTSn1MrG0cJNBqjNFxG1MzL5tNEh1nCzH2LUVl/nKdS/wx5OHQ58F7iu5Hs3PN4FvRsT/BH4G3O0Sn1S6QeCXgO9ONP45mFK6v9ySlMVMx9iVXNasXOaTJEnKwWU+SZKkHAxTkiRJORimJEmScjBMSZIk5WCYkiRJysEwJUmSlINhSpIkKQfDlCRJUg7/H3E6s99vVsI1AAAAAElFTkSuQmCC",
+                        "text/plain": [
+                            "<Figure size 720x360 with 1 Axes>"
+                        ]
+                    },
+                    "metadata": {
+                        "needs_background": "light"
+                    },
+                    "output_type": "display_data"
+                }
+            ],
             "source": [
                 "plt.figure(figsize=(10, 5))\n",
                 "for i in range(4):\n",
@@ -497,7 +419,8 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
@@ -603,7 +526,8 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
@@ -677,16 +601,18 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
-                "data": {
-                    "text/plain": [
-                        "(100, 6)"
-                    ]
-                },
-                "execution_count": 6,
-                "metadata": {},
-                "output_type": "execute_result"
-            }],
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "(100, 6)"
+                        ]
+                    },
+                    "execution_count": 6,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
             "source": [
                 "varss.shape\n"
             ]
@@ -695,7 +621,8 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "data": {
                         "text/plain": [
                             "<matplotlib.collections.PathCollection at 0x1683349a0>"
@@ -736,7 +663,8 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "data": {
                         "text/plain": [
                             "<matplotlib.collections.PathCollection at 0x29596a520>"
@@ -768,25 +696,27 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
-                "data": {
-                    "text/plain": [
-                        "DeviceArray([[-2.9434702 , -1.0610158 , -0.91644555],\n",
-                        "             [-2.9433036 , -1.0609921 , -0.9164234 ],\n",
-                        "             [-2.943137  , -1.0609684 , -0.91640127],\n",
-                        "             [-2.9429703 , -1.0609446 , -0.916379  ],\n",
-                        "             [-2.9428034 , -1.0609208 , -0.91635674],\n",
-                        "             [-2.9426367 , -1.0608972 , -0.91633445],\n",
-                        "             [-2.94247   , -1.0608734 , -0.9163123 ],\n",
-                        "             [-2.9423037 , -1.0608497 , -0.91629004],\n",
-                        "             [-2.942137  , -1.060826  , -0.9162678 ],\n",
-                        "             [-2.9419703 , -1.0608022 , -0.91624564]], dtype=float32)"
-                    ]
-                },
-                "execution_count": 76,
-                "metadata": {},
-                "output_type": "execute_result"
-            }],
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "DeviceArray([[-2.9434702 , -1.0610158 , -0.91644555],\n",
+                            "             [-2.9433036 , -1.0609921 , -0.9164234 ],\n",
+                            "             [-2.943137  , -1.0609684 , -0.91640127],\n",
+                            "             [-2.9429703 , -1.0609446 , -0.916379  ],\n",
+                            "             [-2.9428034 , -1.0609208 , -0.91635674],\n",
+                            "             [-2.9426367 , -1.0608972 , -0.91633445],\n",
+                            "             [-2.94247   , -1.0608734 , -0.9163123 ],\n",
+                            "             [-2.9423037 , -1.0608497 , -0.91629004],\n",
+                            "             [-2.942137  , -1.060826  , -0.9162678 ],\n",
+                            "             [-2.9419703 , -1.0608022 , -0.91624564]], dtype=float32)"
+                        ]
+                    },
+                    "execution_count": 76,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
             "source": [
                 "thetas[x : x + 10]\n"
             ]
@@ -795,14 +725,16 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
-                "name": "stderr",
-                "output_type": "stream",
-                "text": [
-                    "/Users/alexconstantino/.local/share/virtualenvs/research-pVCP8Qup/lib/python3.8/site-packages/jax/_src/tree_util.py:185: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.\n",
-                    "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '\n"
-                ]
-            }],
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/Users/alexconstantino/.local/share/virtualenvs/research-pVCP8Qup/lib/python3.8/site-packages/jax/_src/tree_util.py:185: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.\n",
+                        "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '\n"
+                    ]
+                }
+            ],
             "source": [
                 "import numpy as np\n",
                 "import numpyro\n",
@@ -845,7 +777,8 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [{
+            "outputs": [
+                {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
@@ -947,7 +880,7 @@
         "orig_nbformat": 4,
         "vscode": {
             "interpreter": {
-                "hash": "b6bd0657068c38953c2fe5251f8f61893d47205eb021f5d049a4c9233ce79361"
+                "hash": "ea5f5adf5f977c7a2bc75c836eed5ad36faef5592565920a9031cf920f38b81d"
             }
         }
     },


### PR DESCRIPTION
And add test to ensure it is stable.

- We use the eigen factorization to compute the gradient during the
Newton steps
- We slightly modify the jax_faster routines for improved stability
- We stabilize the final log probability sum by substracting the smallest
element first