### PR TITLE
Add back fast math routines

### DIFF
--- a/research/berry/berrylib/fast_inla.py
+++ b/research/berry/berrylib/fast_inla.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import numpy as np
 import scipy.linalg
 import scipy.stats
+from berrylib.fast_math import jax_fast_invert
 from jax.config import config
 from scipy.special import logit
 
@@ -334,23 +335,6 @@ def jax_opt(y, n, cov, neg_precQ, sigma2, logit_p1, mu_0, tol):
     )
     theta_max, hess_inv, stop = out
     return theta_max, hess_inv
-
-
-def jax_fast_invert(S, d):
-    """
-    Invert a matrix plus a diagonal by iteratively applying the Sherman-Morrison
-    formula. If we are computing Binv = (A + d)^-1,
-    then the arguments are:
-    - S: A^-1
-    - d: d
-    """
-    # NOTE: It's possible to improve performance by about 10% by doing an
-    # incomplete inversion here. In the last iteration through the loop, return
-    # both S and offset. Then, perform .dot(grad) with those components directly.
-    for k in range(d.shape[0]):
-        offset = d[k] / (1 + d[k] * S[k, k])
-        S = S - (offset * (S[k, None, :] * S[:, None, k]))
-    return S
 
 
 @jax.jit

--- a/research/berry/berrylib/fast_math.py
+++ b/research/berry/berrylib/fast_math.py
@@ -1,0 +1,95 @@
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+
+@partial(jax.jit, static_argnames=["omit_constants"])
+def log_normal_pdf(x, mean, prec_eig_vals, prec_eig_vecs, omit_constants=True):
+    """Compute the log of the multivariate normal pdf.
+
+    Using the eigendecomposition is numerically stable. Adapted from scipy.
+    """
+    logdet = -jnp.sum(jnp.log(prec_eig_vals))
+    U = prec_eig_vecs * jnp.sqrt(prec_eig_vals)
+    dev = x - mean
+    # "maha" for "Mahalanobis distance".
+    maha = jnp.square(jnp.dot(dev, U)).sum()
+    if omit_constants:
+        return -0.5 * (maha + logdet)
+    else:
+        rank = len(prec_eig_vals)
+        log2pi = jnp.log(2 * jnp.pi)
+        return -0.5 * (rank * log2pi + maha + logdet)
+
+
+@jax.jit
+def jax_fast_invert(S, d):
+    """
+    Invert a matrix plus a diagonal by iteratively applying the Sherman-Morrison
+    formula. If we are computing Binv = (A + d)^-1,
+    then the arguments are:
+    - S: A^-1
+    - d: d
+    """
+    # NOTE: It's possible to improve performance by about 10% by doing an
+    # incomplete inversion here. In the last iteration through the loop, return
+    # both S and offset. Then, perform .dot(grad) with those components directly.
+    for k in range(d.shape[0]):
+        offset = d[k] / (1 + d[k] * S[k, k])
+        S = S - (offset * (S[k, None, :] * S[:, None, k]))
+    return S
+
+
+@jax.jit
+def jax_faster_inv(D, S):
+    """Compute the inverse of a diagonal matrix D plus a shift S.
+
+    This function uses "Sherman-Morrison" formula:
+    https://en.wikipedia.org/wiki/Sherman–Morrison_formula
+    """
+    D_inverse = 1.0 / D
+    # NB: reusing D_inverse in this line is numerically unstable
+    multiplier = -S / (1 + (S / D).sum())
+    M = multiplier * jnp.outer(D_inverse, D_inverse)
+    M = M + jnp.diag(D_inverse)
+    return M
+
+
+@jax.jit
+def jax_faster_inv_diag(D, S):
+    """Compute the diagonal of the inverse of a diagonal matrix D plus a shift S.
+
+    This function uses "Sherman-Morrison" formula:
+    https://en.wikipedia.org/wiki/Sherman–Morrison_formula
+    """
+    D_inverse = 1.0 / D
+    # NB: reusing D_inverse in this line is numerically unstable
+    multiplier = -S / (1 + (S / D).sum())
+    return multiplier * D_inverse * D_inverse + D_inverse
+
+
+@jax.jit
+def jax_faster_inv_product(D, S, G):
+    """Compute (diag(D)+S)^-1 @ G.
+
+    This function uses "Sherman-Morrison" formula:
+    https://en.wikipedia.org/wiki/Sherman–Morrison_formula
+    """
+    D_norm = jnp.abs(D).sum()
+    D_normed = D / D_norm
+    return (-S * (G / D_normed).sum() / (D_norm + (S / D_normed).sum()) + G) / D
+
+
+@jax.jit
+def jax_faster_log_det(D, S):
+    """Compute the log determinant of a diagnal matrix D plus a shift S.
+
+    Valid only if the determinant is positive.
+
+    This function uses "Sherman-Morrison for determinants"
+    https://en.wikipedia.org/wiki/Matrix_determinant_lemma
+    """
+    detD_inverse = jnp.log(D).sum()
+    newdeterminant = detD_inverse + jnp.log1p((S / D).sum())
+    return newdeterminant

--- a/research/berry/berrylib/test_fast_math.py
+++ b/research/berry/berrylib/test_fast_math.py
@@ -1,0 +1,60 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+from berrylib.fast_math import (
+    jax_fast_invert,
+    jax_faster_inv,
+    jax_faster_inv_diag,
+    jax_faster_inv_product,
+    jax_faster_log_det,
+    log_normal_pdf,
+)
+
+
+def test_faster_linalg():
+    num_iter = 1000
+    key = jax.random.PRNGKey(0)
+    d = jax.random.uniform(key, (num_iter, 4))
+    s = jax.random.uniform(key, (num_iter, 1))
+    g = jax.random.uniform(key, (num_iter, 4))
+    atol = 1e-6
+    for d, s, g in zip(d, s, g):
+        m = np.diag(d) + s
+        sign, expected = np.linalg.slogdet(m)
+        if sign < 0:
+            # If the determinant is negative, the matrix is not positive definite
+            continue
+        # Determinant
+        np.testing.assert_allclose(jax_faster_log_det(d, s), expected, atol=atol)
+
+        # Inverse
+        expected = np.linalg.inv(m)
+        np.testing.assert_allclose(jax_faster_inv(d, s), expected, atol=atol)
+        np.testing.assert_allclose(
+            jax_fast_invert(
+                jnp.linalg.inv(jnp.full_like(expected, s) + jnp.diag(jnp.repeat(1, 4))),
+                d - 1,
+            ),
+            expected,
+            atol=atol,
+        )
+
+        # Inverse product
+        expected = np.linalg.inv(m) @ g
+        np.testing.assert_allclose(jax_faster_inv_product(d, s, g), expected, atol=atol)
+
+        # Inverse diagonal
+        expected = np.diag(np.linalg.inv(m))
+        np.testing.assert_allclose(jax_faster_inv_diag(d, s), expected, atol=atol)
+
+
+def test_log_normal_pdf():
+    x = np.array([0.0, 0.5])
+    mu = np.array([0, 1])
+    cov = np.array([[2, 0.5], [0.5, 2]])
+    prec = np.linalg.inv(cov)
+    vals, vecs = np.linalg.eigh(prec)
+    expected = jax.scipy.stats.multivariate_normal.logpdf(x, mu, cov)
+    np.testing.assert_allclose(
+        log_normal_pdf(x, mu, vals, vecs, omit_constants=False), expected
+    )


### PR DESCRIPTION
We restore the utility functions and tests removed in 1d29ca2.

These routines apply formulas such as Sherman–Morrison to compute
inverses, determinants, and normal PDFs faster than typical library
functions.